### PR TITLE
feat: disable automerge server sync if unauthenticated

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -62,7 +62,6 @@
 		"@testing-library/user-event": "^14.5.2",
 		"@types/node": "^22.13.1",
 		"@types/ws": "^8.18.1",
-		"@vitejs/plugin-basic-ssl": "^2.0.0",
 		"eslint": "^9.19.0",
 		"eslint-config-prettier": "^10.0.1",
 		"eslint-plugin-import": "^2.31.0",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -161,9 +161,6 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
-      '@vitejs/plugin-basic-ssl':
-        specifier: ^2.0.0
-        version: 2.0.0(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
       eslint:
         specifier: ^9.19.0
         version: 9.27.0(jiti@2.4.2)
@@ -1401,12 +1398,6 @@ packages:
   '@typescript-eslint/visitor-keys@8.32.1':
     resolution: {integrity: sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@vitejs/plugin-basic-ssl@2.0.0':
-    resolution: {integrity: sha512-gc9Tjg8bUxBVSTzeWT3Njc0Cl3PakHFKdNfABnZWiUgbxqmHDEn7uECv3fHVylxoYgNzAcmU7ZrILz+BwSo3sA==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    peerDependencies:
-      vite: ^6.0.0
 
   '@vitest/expect@2.0.5':
     resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
@@ -5117,10 +5108,6 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.32.1
       eslint-visitor-keys: 4.2.0
-
-  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))':
-    dependencies:
-      vite: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
 
   '@vitest/expect@2.0.5':
     dependencies:

--- a/client/src/core/context/ui/automerge.ts
+++ b/client/src/core/context/ui/automerge.ts
@@ -1,5 +1,4 @@
 import { Repo, type NetworkAdapterInterface } from "@automerge/automerge-repo";
-import { BrowserWebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
 import { IndexedDBStorageAdapter } from "@automerge/automerge-repo-storage-indexeddb";
 import { invariant } from "es-toolkit";
 
@@ -10,9 +9,7 @@ const storage = new IndexedDBStorageAdapter(
 
 invariant(import.meta.env.VITE_AUTOMERGE_WSS, "Automerge API not specified");
 
-const network: NetworkAdapterInterface[] = [
-	new BrowserWebSocketClientAdapter(import.meta.env.VITE_AUTOMERGE_WSS),
-];
+export const network: NetworkAdapterInterface[] = [];
 
 export const repo = new Repo({
 	storage,

--- a/client/src/core/context/ui/provider-mock.tsx
+++ b/client/src/core/context/ui/provider-mock.tsx
@@ -1,5 +1,8 @@
+import { BrowserWebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
 import { I18nProvider } from "@kobalte/core";
 import { QueryClient, QueryClientProvider } from "@tanstack/solid-query";
+import { AuthnContext } from "core/context/authn";
+import { useContext } from "core/context/utils";
 import { RepoContext } from "solid-automerge";
 import {
 	createEffect,
@@ -11,7 +14,7 @@ import {
 	type ParentProps,
 } from "solid-js";
 import { ToastList, ToastRegion } from "ui/toast";
-import { repo } from "./automerge";
+import { network, repo } from "./automerge";
 import { UiContext } from "./provider";
 import { useStore, type UiSvc } from "./store";
 
@@ -23,6 +26,8 @@ export const UiProviderMock: Component<
 	ParentProps<UiProviderMockProps>
 > = props => {
 	const value = useStore();
+	const authnContext = useContext(AuthnContext);
+
 	const withDefaultProps = mergeProps(
 		{
 			svc: value,
@@ -58,6 +63,27 @@ export const UiProviderMock: Component<
 
 	onMount(() => {
 		withDefaultProps.svc().actions.init();
+	});
+
+	// COMMENT TO TEST AUTOMERGE WITH MOCK PROVIDERS
+	// AND ADD ADAPTER TO `network`
+	createEffect(() => {
+		// if authenticated then we want automerge sync
+		if (authnContext().keycloak?.authenticated) {
+			network.push(
+				new BrowserWebSocketClientAdapter(
+					import.meta.env.VITE_AUTOMERGE_WSS,
+				),
+			);
+
+			return;
+		}
+
+		// otherwise remove all network adapters if any
+		// automerge allows for the array to be changed at runtime but we can't reassign it
+		while (network.length) {
+			network.pop();
+		}
 	});
 
 	return (

--- a/client/src/core/context/ui/provider.tsx
+++ b/client/src/core/context/ui/provider.tsx
@@ -1,6 +1,9 @@
+import { BrowserWebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
 import { I18nProvider } from "@kobalte/core/i18n";
 import { QueryClientProvider, type QueryClient } from "@tanstack/solid-query";
+import { AuthnContext } from "core/context/authn";
 import { createUiContext } from "core/context/initializers";
+import { useContext } from "core/context/utils";
 import { RepoContext } from "solid-automerge";
 import {
 	createContext,
@@ -12,13 +15,14 @@ import {
 	type ParentProps,
 } from "solid-js";
 import { ToastList, ToastRegion } from "ui/toast";
-import { repo } from "./automerge";
+import { network, repo } from "./automerge";
 import { useStore, type UiSvc } from "./store";
 
 export const UiContext = createContext<Accessor<UiSvc>>(createUiContext);
 
 export const UiProvider: Component<ParentProps> = props => {
 	const value = useStore();
+	const authnContext = useContext(AuthnContext);
 
 	createEffect(() => {
 		if (value().isInitialLoading()) {
@@ -43,6 +47,25 @@ export const UiProvider: Component<ParentProps> = props => {
 			}
 
 			root.classList.add(value().theme);
+		}
+	});
+
+	createEffect(() => {
+		// if authenticated then we want automerge sync
+		if (authnContext().keycloak?.authenticated) {
+			network.push(
+				new BrowserWebSocketClientAdapter(
+					import.meta.env.VITE_AUTOMERGE_WSS,
+				),
+			);
+
+			return;
+		}
+
+		// otherwise remove all network adapters if any
+		// automerge allows for the array to be changed at runtime but we can't reassign it
+		while (network.length) {
+			network.pop();
 		}
 	});
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -2,7 +2,6 @@ import { Repo } from "@automerge/automerge-repo";
 import { NodeWSServerAdapter } from "@automerge/automerge-repo-network-websocket";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import { default as tailwindcss } from "@tailwindcss/vite";
-// import { default as basicSsl } from "@vitejs/plugin-basic-ssl";
 import { join } from "node:path";
 import { defineConfig, type Plugin } from "vite";
 import { default as viteCompression } from "vite-plugin-compression";
@@ -53,9 +52,6 @@ export default defineConfig({
 		wasm(),
 		topLevelAwait(),
 		automergeWsServer(),
-		// TODO: testing deployed version first
-		// think will need to be a trusted cert so that workers doesn't error out
-		// basicSsl(),
 	],
 	resolve: {
 		alias: {


### PR DESCRIPTION
might make sense to split automerge and query client to its own context, leaving it in ui for now

TODO: something is causing kc to return CORS errors, was working before, unsure if client update or server update which is causing the issue

think because of nginx: https://github.com/keycloak/keycloak/issues/10817

https://www.keycloak.org/server/reverseproxy#_configure_the_reverse_proxy_headers

keycloak errors are from the server