### PR TITLE
fix: set auth cookie sameSite back to Strict

### DIFF
--- a/client/src/core/context/authn/store/index.ts
+++ b/client/src/core/context/authn/store/index.ts
@@ -72,6 +72,7 @@ export const useStore = createWithSignal<AuthnSvc>((set, get) => {
 					),
 				),
 				secure: import.meta.env.PROD,
+				sameSite: "Strict",
 			},
 		);
 


### PR DESCRIPTION
was checking against the pages site instead of the one on `skulpture` domain which was causing the unauthorised errors