### PR TITLE
fix: gender and relationship status not being saved

### DIFF
--- a/client/src/feat/my-passport-form/hooks/useMyPassportForm.ts
+++ b/client/src/feat/my-passport-form/hooks/useMyPassportForm.ts
@@ -75,6 +75,7 @@ export const useMyPassportForm = () => {
 			),
 		enabled: Boolean(getValue(form, "personalDetails.countryOfBirthCode")),
 		placeholderData: [],
+		staleTime: Infinity,
 	}));
 
 	const [handle] = createResource(async () => {

--- a/client/src/feat/my-passport-form/steps/personal-details/index.tsx
+++ b/client/src/feat/my-passport-form/steps/personal-details/index.tsx
@@ -2,6 +2,8 @@ import { getValue, type FieldEvent } from "@modular-forms/solid";
 import { useI18n } from "core/context/i18n";
 import type { resources } from "feat/my-passport-form/resources/i18n/en-US";
 import {
+	Gender,
+	RelationshipStatus,
 	type MyPassportForm,
 	type StepProps,
 } from "feat/my-passport-form/types";
@@ -199,15 +201,14 @@ export const PersonalDetails: Component<StepProps> = props => {
 									never,
 									"input"
 								>
-									form={props.form}
 									{...field}
 									{...fieldProps}
+									form={props.form}
 									value={field.value ?? null}
-									options={Object.keys(
-										props.dropdownOptions()
-											?.genderOptions ??
-											Object.create(null),
+									options={Object.keys(Gender).filter(key =>
+										Number.isNaN(Number(key)),
 									)}
+									optionValue={gender => gender}
 									placeholder={t(
 										"form.personalDetails.genderCode.placeholder",
 									)}
@@ -266,10 +267,11 @@ export const PersonalDetails: Component<StepProps> = props => {
 									{...fieldProps}
 									value={field.value ?? null}
 									options={Object.keys(
-										props.dropdownOptions()
-											?.relationshipStatusOptions ??
-											Object.create(null),
-									)}
+										RelationshipStatus,
+									).filter(key => Number.isNaN(Number(key)))}
+									optionValue={relationshipStatus =>
+										relationshipStatus
+									}
 									placeholder={t(
 										"form.personalDetails.relationshipStatusCode.placeholder",
 									)}
@@ -284,7 +286,7 @@ export const PersonalDetails: Component<StepProps> = props => {
 												return (
 													<>
 														<div>
-															{state.selectedOption()}{" "}
+															{state.selectedOption()}
 														</div>
 
 														<SelectClearSelection
@@ -475,6 +477,7 @@ export const PersonalDetails: Component<StepProps> = props => {
 										props.dropdownOptions()?.stateOptions ??
 											[],
 									)}
+									optionValue={state => state}
 									value={field.value ?? ""}
 									placeholder={t(
 										"form.personalDetails.stateOfBirth.placeholder",


### PR DESCRIPTION
TODO:
- unsure what's causing it but with select if we use async options none of them are being saved, default value when resetting has values as `null` (in the automerge doc):

<img width="531" alt="image" src="https://github.com/user-attachments/assets/6c3f8bb8-e601-438f-b8ec-8cf30ccac0d1" />

but they are being set here correctly:

<img width="531" alt="image" src="https://github.com/user-attachments/assets/a3fd411c-0b16-42e9-ae96-a2deaca4fa6e" />

only happens for select, combobox and countries autocorrect seem to be ok
