### PR TITLE
fix: stop sync between form values and automerge doc until initial values are loaded

### DIFF
--- a/client/src/feat/my-passport-form/hooks/useMyPassportForm.ts
+++ b/client/src/feat/my-passport-form/hooks/useMyPassportForm.ts
@@ -1,4 +1,4 @@
-import type { AnyDocumentId } from "@automerge/automerge-repo";
+import type { AnyDocumentId, DocHandle } from "@automerge/automerge-repo";
 import {
 	createForm,
 	getValue,
@@ -79,12 +79,26 @@ export const useMyPassportForm = () => {
 	}));
 
 	const [handle] = createResource(async () => {
+		// not ideal that we are performing side effects here
+		// but we don't want the page to load until we've set the initial data
+		const resetFormValues = (handle: DocHandle<MyPassportForm>) => {
+			if (!import.meta.env.PROD) {
+				console.debug("initialValues", handle.doc());
+			}
+
+			reset(form, {
+				initialValues: handle.doc(),
+			});
+		};
+
 		if (searchParams.automergeUrl) {
 			const handle = await repo.find<MyPassportForm>(
 				searchParams.automergeUrl as AnyDocumentId,
 			);
 
 			await handle.whenReady();
+
+			resetFormValues(handle);
 
 			return handle;
 		}
@@ -156,6 +170,10 @@ export const useMyPassportForm = () => {
 	};
 
 	createEffect(() => {
+		if (handle.loading) {
+			return;
+		}
+
 		const dirtyFields = flattenObject(
 			getValues(form, {
 				shouldDirty: true,
@@ -168,18 +186,12 @@ export const useMyPassportForm = () => {
 
 		handle()?.change(doc => {
 			Object.entries(dirtyFields).forEach(([path, value]) => {
+				if (!import.meta.env.PROD) {
+					console.debug("set", path, value);
+				}
+
 				set(doc, path, value);
 			});
-		});
-	});
-
-	createEffect(() => {
-		if (handle.loading) {
-			return;
-		}
-
-		reset(form, {
-			initialValues: handle()?.doc(),
 		});
 	});
 
@@ -201,6 +213,8 @@ export const useMyPassportForm = () => {
 			return;
 		}
 
+		const currentUuid = routeParams.uuid;
+
 		const updateExistingFormEntry = () => {
 			invariant(
 				handle()?.url,
@@ -216,7 +230,7 @@ export const useMyPassportForm = () => {
 
 			const updatedApplications = existingApplications.map(
 				application => {
-					if (application.uuid === routeParams.uuid) {
+					if (application.uuid === currentUuid) {
 						return {
 							...application,
 							...getValues(form),
@@ -288,7 +302,7 @@ export const useMyPassportForm = () => {
 			);
 		};
 
-		if (routeParams.uuid) {
+		if (currentUuid) {
 			queueMicrotask(() => updateExistingFormEntry());
 
 			return;

--- a/client/src/feat/my-passport-form/hooks/useMyPassportForm.ts
+++ b/client/src/feat/my-passport-form/hooks/useMyPassportForm.ts
@@ -196,8 +196,11 @@ export const useMyPassportForm = () => {
 	});
 
 	onCleanup(() => {
+		invariant(form, "Form is not defined");
+
+		const currentUuid = routeParams.uuid;
 		const deleteBlankDocument = async () => {
-			if (form.dirty || routeParams.uuid) {
+			if (form.dirty || currentUuid) {
 				return;
 			}
 
@@ -209,6 +212,8 @@ export const useMyPassportForm = () => {
 	});
 
 	onCleanup(() => {
+		invariant(form, "Form is not defined");
+
 		if (!form.dirty) {
 			return;
 		}

--- a/client/src/feat/my-passport-form/steps/personal-details/index.tsx
+++ b/client/src/feat/my-passport-form/steps/personal-details/index.tsx
@@ -2,8 +2,6 @@ import { getValue, type FieldEvent } from "@modular-forms/solid";
 import { useI18n } from "core/context/i18n";
 import type { resources } from "feat/my-passport-form/resources/i18n/en-US";
 import {
-	Gender,
-	RelationshipStatus,
 	type MyPassportForm,
 	type StepProps,
 } from "feat/my-passport-form/types";
@@ -204,9 +202,11 @@ export const PersonalDetails: Component<StepProps> = props => {
 									{...field}
 									{...fieldProps}
 									form={props.form}
-									value={field.value ?? null}
-									options={Object.keys(Gender).filter(key =>
-										Number.isNaN(Number(key)),
+									value={field.value ?? ""}
+									options={Object.keys(
+										props.dropdownOptions()
+											?.genderOptions ??
+											Object.create(null),
 									)}
 									optionValue={gender => gender}
 									placeholder={t(
@@ -262,13 +262,15 @@ export const PersonalDetails: Component<StepProps> = props => {
 									never,
 									"input"
 								>
-									form={props.form}
 									{...field}
 									{...fieldProps}
-									value={field.value ?? null}
+									form={props.form}
+									value={field.value ?? ""}
 									options={Object.keys(
-										RelationshipStatus,
-									).filter(key => Number.isNaN(Number(key)))}
+										props.dropdownOptions()
+											?.relationshipStatusOptions ??
+											Object.create(null),
+									)}
 									optionValue={relationshipStatus =>
 										relationshipStatus
 									}


### PR DESCRIPTION
issue:
- on initial render not everything is loaded yet and select calls `onChange` with `null` causing any initial value which to be overwritten

- starts off with initial value and then gets set to `null` causing the options to seem like they're not saving correctly
![image](https://github.com/user-attachments/assets/907eb250-b47a-466f-a17a-ddb8a20490cd)

fixed:

https://github.com/user-attachments/assets/7ef870ad-e179-4b9f-a64d-f9da4a52ad8a

not fixed:

https://github.com/user-attachments/assets/8901017d-7729-4652-9a14-e577c2795457
