### PR TITLE
fix: combobox option not showing when page refreshed

### DIFF
--- a/client/src/feat/my-passport-form/steps/personal-details/index.tsx
+++ b/client/src/feat/my-passport-form/steps/personal-details/index.tsx
@@ -452,70 +452,78 @@ export const PersonalDetails: Component<StepProps> = props => {
 			</div>
 
 			<props.Field name="personalDetails.stateOfBirth">
-				{(field, fieldProps) => (
-					<>
-						<Show
-							when={getValue(
-								props.form,
-								"personalDetails.countryOfBirthCode",
-							)}>
-							<InputGroup>
-								<Label
-									info={t(
-										"form.personalDetails.stateOfBirth.info",
-									)}>
-									{t(
-										"form.personalDetails.stateOfBirth.label",
-									)}
-								</Label>
+				{(field, fieldProps) => {
+					const findOption = (value?: string) =>
+						props
+							.dropdownOptions()
+							?.stateOptions.find(option => option === value);
 
-								<ModularFormsCombobox<
-									string,
-									MyPassportForm,
-									never,
-									"input"
-								>
-									{...field}
-									{...fieldProps}
-									form={props.form}
-									options={Object.values(
-										props.dropdownOptions()?.stateOptions ??
-											[],
-									)}
-									optionValue={state => state}
-									value={field.value ?? ""}
-									placeholder={t(
-										"form.personalDetails.stateOfBirth.placeholder",
-									)}
-									itemComponent={props => (
-										<ComboboxItem item={props.item}>
-											{props.item.rawValue}
-										</ComboboxItem>
-									)}>
-									<Combobox.Control<string>>
-										{state => {
-											return (
-												<>
-													<ComboboxTrigger class="relative">
-														<ComboboxInput />
+					return (
+						<>
+							<Show
+								when={getValue(
+									props.form,
+									"personalDetails.countryOfBirthCode",
+								)}>
+								<InputGroup>
+									<Label
+										info={t(
+											"form.personalDetails.stateOfBirth.info",
+										)}>
+										{t(
+											"form.personalDetails.stateOfBirth.label",
+										)}
+									</Label>
 
-														<ComboboxClearSelection
-															selectedOptions={state.selectedOptions()}
-															onClear={
-																state.clear
-															}
-														/>
-													</ComboboxTrigger>
-												</>
-											);
-										}}
-									</Combobox.Control>
-									<ComboboxContent />
-								</ModularFormsCombobox>
-							</InputGroup>
-						</Show>
-					</>
-				)}
+									<ModularFormsCombobox<
+										string,
+										MyPassportForm,
+										never,
+										"input"
+									>
+										{...field}
+										{...fieldProps}
+										form={props.form}
+										value={findOption(field.value) ?? ""}
+										options={
+											props.dropdownOptions()
+												?.stateOptions ?? []
+										}
+										optionValue={state => state}
+										// value={field.value ?? ""}
+										placeholder={t(
+											"form.personalDetails.stateOfBirth.placeholder",
+										)}
+										itemComponent={props => (
+											<ComboboxItem item={props.item}>
+												{props.item.rawValue}
+											</ComboboxItem>
+										)}>
+										<Combobox.Control<string>>
+											{state => {
+												return (
+													<>
+														<ComboboxTrigger class="relative">
+															<ComboboxInput />
+
+															<ComboboxClearSelection
+																selectedOptions={state.selectedOptions()}
+																onClear={
+																	state.clear
+																}
+															/>
+														</ComboboxTrigger>
+													</>
+												);
+											}}
+										</Combobox.Control>
+										<ComboboxContent />
+									</ModularFormsCombobox>
+								</InputGroup>
+							</Show>
+						</>
+					);
+				}}
 			</props.Field>
 		</>
 	);


### PR DESCRIPTION
state options do not suspend (because placeholder data and so that the page doesn't go to a loading state each time states are fetched depending on the country) so when the combobox initially shows on page refresh there are no options so any selected value is not shown but the value does not update when states are fetched because the field value has not changed. does not happen when editing a form just refreshing the edit page

not fixed:

https://github.com/user-attachments/assets/e5f23ee5-71bf-4e89-bb64-58ebd6131746

fixed:

https://github.com/user-attachments/assets/a57f7197-a954-4714-bdd7-6057ecf6238c


