### PR TITLE
fix: preserve hash when creating redirect uri

### DIFF
--- a/client/src/core/context/authn/store/utils.ts
+++ b/client/src/core/context/authn/store/utils.ts
@@ -2,9 +2,17 @@ export const createRedirectUrl = (
 	authRedirectUri: string,
 	redirectPath?: string,
 ) => {
+	const getRedirectPath = (redirectPath?: string) => {
+		if (!redirectPath) {
+			return window.location.hash;
+		}
+
+		return [redirectPath, window.location.hash].join("");
+	};
+
 	const params = new URLSearchParams({
 		...Object.fromEntries(new URLSearchParams(window.location.search)),
-		redirectPath: redirectPath ?? "",
+		redirectPath: getRedirectPath(redirectPath),
 	});
 
 	params.forEach((value, key) => {


### PR DESCRIPTION
crops up on safari but not chrome:

https://github.com/user-attachments/assets/3e36dd0f-c738-4b7f-bc74-968c04727048

