### PR TITLE
chore: revert host rule change and update domains for cert

### DIFF
--- a/api/docker-compose.dev.yml
+++ b/api/docker-compose.dev.yml
@@ -32,6 +32,7 @@ services:
       --entryPoints.websecure.asDefault=true
       --entryPoints.web.http.redirections.entryPoint.to=websecure
       --entryPoints.web.http.redirections.entryPoint.scheme=https
+      --ping=true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./traefik:/traefik

--- a/api/docker-compose.dev.yml
+++ b/api/docker-compose.dev.yml
@@ -73,7 +73,7 @@ services:
       replicas: 1
       labels:
         traefik.enable: "true"
-        traefik.http.routers.imigresen-api-dev.rule: PathPrefix(`/`)
+        traefik.http.routers.imigresen-api-dev.rule: Host(`imigresen-api-dev.skulpture.xyz`)
         traefik.http.routers.imigresen-api-dev.tls.domains.main: skulpture.xyz
         traefik.http.routers.imigresen-api-dev.tls.domains.sans: "*.skulpture.xyz"
         traefik.http.services.imigresen-api-dev-service.loadbalancer.server.port: 3000

--- a/infrastructure/main.go
+++ b/infrastructure/main.go
@@ -317,6 +317,8 @@ func main() {
 			RequestPath:      pulumi.String("/ping"),
 			CheckIntervalSec: pulumi.Int(30),
 			TimeoutSec:       pulumi.Int(30),
+			// traefik ping: https://doc.traefik.io/traefik/reference/install-configuration/observability/healthcheck/
+			Port: pulumi.Int(8080),
 		})
 		if err != nil {
 			return nil, err

--- a/infrastructure/main.go
+++ b/infrastructure/main.go
@@ -256,7 +256,8 @@ func main() {
 			UnhealthyThreshold: pulumi.Int(10),
 			HttpsHealthCheck: &compute.HealthCheckHttpsHealthCheckArgs{
 				RequestPath: pulumi.String("/ping"),
-				Port:        pulumi.Int(443),
+				// traefik ping: https://doc.traefik.io/traefik/reference/install-configuration/observability/healthcheck/
+				Port: pulumi.Int(8080),
 			},
 		})
 		if err != nil {

--- a/infrastructure/main.go
+++ b/infrastructure/main.go
@@ -304,7 +304,6 @@ func main() {
 			Managed: &compute.ManagedSslCertificateManagedArgs{
 				Domains: pulumi.StringArray{
 					pulumi.String("imigresen-api-dev.skulpture.xyz"),
-					pulumi.String("imigresen.skulpture.xyz"),
 				},
 			},
 		})


### PR DESCRIPTION
#243 

host rule change shouldn't be the reason but for some reason the vm completely stopped responding after the change was deployed. might be just container restart loop causing the entire thing to crash? unsure

existing disk has been removed so hard reset

