### PR TITLE
chore: update classpath to include uberjar of common instead of relying on lein install which uses thin jars

### DIFF
--- a/api/imigresen-api/Dockerfile
+++ b/api/imigresen-api/Dockerfile
@@ -14,5 +14,5 @@ COPY --from=build /build/imigresen-api/target/uberjar/common-SNAPSHOT-standalone
 COPY --from=build /build/imigresen-api/target/uberjar/api-0.1.0-SNAPSHOT-standalone.jar /app/api-0.1.0-SNAPSHOT-standalone.jar
 
 # Common uberjar includes migrations which are otherwise not included if we were to just do a `lein install`
-# and build the API
+# (because it uses snapshots) and build the API
 ENTRYPOINT ["java", "-showversion", "-cp", "common-SNAPSHOT-standalone.jar:api-0.1.0-SNAPSHOT-standalone.jar", "imigresen_api.app.core.main"]

--- a/api/imigresen-api/Dockerfile
+++ b/api/imigresen-api/Dockerfile
@@ -5,11 +5,14 @@ WORKDIR /build
 COPY --from=common . ./imigresen-common
 COPY . ./imigresen-api
 
-RUN cd imigresen-common && lein install
+RUN cd imigresen-common && lein build
 RUN cd imigresen-api && lein build
 
 FROM eclipse-temurin:24-jre-alpine
 
+COPY --from=build /build/imigresen-api/target/uberjar/common-SNAPSHOT-standalone.jar /app/common-standalone.jar
 COPY --from=build /build/imigresen-api/target/uberjar/api-0.1.0-SNAPSHOT-standalone.jar /app/api-0.1.0-SNAPSHOT-standalone.jar
 
-ENTRYPOINT ["java", "-showversion", "-jar", "/app/api-0.1.0-SNAPSHOT-standalone.jar"]
+# Common uberjar includes migrations which are otherwise not included if we were to just do a `lein install`
+# and build the API
+ENTRYPOINT ["java", "-showversion", "-cp", "common-SNAPSHOT-standalone.jar:api-0.1.0-SNAPSHOT-standalone.jar", "imigresen_api.app.core.main"]

--- a/api/imigresen-api/Dockerfile
+++ b/api/imigresen-api/Dockerfile
@@ -11,7 +11,7 @@ RUN cd imigresen-common && lein build
 
 FROM eclipse-temurin:24-jre-alpine
 
-COPY --from=build /build/imigresen-common/target/uberjar/common-SNAPSHOT-standalone.jar /app/common-standalone.jar
+COPY --from=build /build/imigresen-common/target/common-SNAPSHOT-standalone.jar /app/common-standalone.jar
 COPY --from=build /build/imigresen-api/target/uberjar/api-0.1.0-SNAPSHOT-standalone.jar /app/api-standalone.jar
 
 # Common uberjar includes migrations which are otherwise not included if we were to just do a `lein install`

--- a/api/imigresen-api/Dockerfile
+++ b/api/imigresen-api/Dockerfile
@@ -14,5 +14,5 @@ COPY --from=build /build/imigresen-api/target/uberjar/common-SNAPSHOT-standalone
 COPY --from=build /build/imigresen-api/target/uberjar/api-0.1.0-SNAPSHOT-standalone.jar /app/api-standalone.jar
 
 # Common uberjar includes migrations which are otherwise not included if we were to just do a `lein install`
-# (because it uses snapshots) and build the API
+# (because it uses thin jars) and build the API
 ENTRYPOINT ["java", "-showversion", "-cp", "common-standalone.jar:api-standalone.jar", "imigresen_api.app.core.main"]

--- a/api/imigresen-api/Dockerfile
+++ b/api/imigresen-api/Dockerfile
@@ -16,4 +16,4 @@ COPY --from=build /build/imigresen-api/target/uberjar/api-0.1.0-SNAPSHOT-standal
 
 # Common uberjar includes migrations which are otherwise not included if we were to just do a `lein install`
 # (because it uses thin jars) and build the API
-ENTRYPOINT ["java", "-showversion", "-cp", "common-standalone.jar:api-standalone.jar", "imigresen_api.app.core.main"]
+ENTRYPOINT ["java", "-showversion", "-cp", "/app/common-standalone.jar:/app/api-standalone.jar", "imigresen_api.app.core.main"]

--- a/api/imigresen-api/Dockerfile
+++ b/api/imigresen-api/Dockerfile
@@ -10,7 +10,7 @@ RUN cd imigresen-api && lein build
 
 FROM eclipse-temurin:24-jre-alpine
 
-COPY --from=build /build/imigresen-api/target/uberjar/common-SNAPSHOT-standalone.jar /app/common-standalone.jar
+COPY --from=build /build/imigresen-common/target/uberjar/common-SNAPSHOT-standalone.jar /app/common-standalone.jar
 COPY --from=build /build/imigresen-api/target/uberjar/api-0.1.0-SNAPSHOT-standalone.jar /app/api-standalone.jar
 
 # Common uberjar includes migrations which are otherwise not included if we were to just do a `lein install`

--- a/api/imigresen-api/Dockerfile
+++ b/api/imigresen-api/Dockerfile
@@ -5,8 +5,9 @@ WORKDIR /build
 COPY --from=common . ./imigresen-common
 COPY . ./imigresen-api
 
-RUN cd imigresen-common && lein build
+RUN cd imigresen-common && lein install
 RUN cd imigresen-api && lein build
+RUN cd imigresen-common && lein build
 
 FROM eclipse-temurin:24-jre-alpine
 

--- a/api/imigresen-api/Dockerfile
+++ b/api/imigresen-api/Dockerfile
@@ -11,8 +11,8 @@ RUN cd imigresen-api && lein build
 FROM eclipse-temurin:24-jre-alpine
 
 COPY --from=build /build/imigresen-api/target/uberjar/common-SNAPSHOT-standalone.jar /app/common-standalone.jar
-COPY --from=build /build/imigresen-api/target/uberjar/api-0.1.0-SNAPSHOT-standalone.jar /app/api-0.1.0-SNAPSHOT-standalone.jar
+COPY --from=build /build/imigresen-api/target/uberjar/api-0.1.0-SNAPSHOT-standalone.jar /app/api-standalone.jar
 
 # Common uberjar includes migrations which are otherwise not included if we were to just do a `lein install`
 # (because it uses snapshots) and build the API
-ENTRYPOINT ["java", "-showversion", "-cp", "common-SNAPSHOT-standalone.jar:api-0.1.0-SNAPSHOT-standalone.jar", "imigresen_api.app.core.main"]
+ENTRYPOINT ["java", "-showversion", "-cp", "common-standalone.jar:api-standalone.jar", "imigresen_api.app.core.main"]


### PR DESCRIPTION
migrations are bundled with common now and expected to be in common class path

#259 