### PR TITLE
chore: update compose env and add healthcheck back

### DIFF
--- a/api/imigresen-api/docker-compose.dev.yml
+++ b/api/imigresen-api/docker-compose.dev.yml
@@ -54,7 +54,6 @@ services:
       KC_OAUTH_CLIENT_ID: ${KC_OAUTH_CLIENT_ID}
       KC_OAUTH_CLIENT_SECRET: ${KC_SECRET}
       PG_CONNECTION_STRING: ${PG_CONNECTION_STRING}
-      DB_INIT_SCRIPT: ${DB_INIT_SCRIPT}
       DB_INIT_IN_TRANSACTION: ${DB_INIT_IN_TRANSACTION}
       DB_MIGRATION_TABLE_NAME: ${DB_MIGRATION_TABLE_NAME}
       DB_SEED_MIGRATION_TABLE_NAME: ${DB_SEED_MIGRATION_TABLE_NAME}
@@ -83,6 +82,12 @@ services:
       nofile:
         soft: 20000
         hard: 20000
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/ping || exit 1" ]
+      interval: 1m30s
+      timeout: 1m
+      retries: 5
+      start_period: 3m
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib


### PR DESCRIPTION
health check so that swarm rolls out the task updates instead of taking both services down which causes the vm to report as unhealthy and instance terminated while task deployments are in progress

init script is now bundled so not necessary