### PR TITLE
chore: remove on pull_request and instead use pull_request_target for build and deploy actions

### DIFF
--- a/.github/workflows/build-services.yml
+++ b/.github/workflows/build-services.yml
@@ -1,8 +1,6 @@
 name: Build services
 
 on:
-  pull_request:
-    branches: [master, staging, dev]
   pull_request_target:
     branches: [master, staging, dev]
   workflow_dispatch:

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,8 +1,6 @@
 name: Build and Publish Storybook to GitHub Pages
 
 on:
-  pull_request:
-    branches: [master, staging, dev]
   pull_request_target:
     branches: [master, staging, dev]
   push:


### PR DESCRIPTION
thought just the action is taken into account and that if we have both the only the one that runs counts