### PR TITLE
chore: reduce autohealing policy interval and timeout to defaults

### DIFF
--- a/infrastructure/main.go
+++ b/infrastructure/main.go
@@ -250,8 +250,8 @@ func main() {
 
 		autohealing, err := compute.NewHealthCheck(ctx, fmt.Sprintf("%s-dev-autohealing", COMPUTE_INSTANCE_NAME.Value()), &compute.HealthCheckArgs{
 			Name:               pulumi.Sprintf("%s-dev-autohealing", COMPUTE_INSTANCE_NAME.Value()),
-			CheckIntervalSec:   pulumi.Int(120),
-			TimeoutSec:         pulumi.Int(10),
+			CheckIntervalSec:   pulumi.Int(5),
+			TimeoutSec:         pulumi.Int(5),
 			HealthyThreshold:   pulumi.Int(2),
 			UnhealthyThreshold: pulumi.Int(10),
 			HttpsHealthCheck: &compute.HealthCheckHttpsHealthCheckArgs{


### PR DESCRIPTION
#233 

if too long instance just reports as unhealthy and gets torn down, reporting as healthy now:

<img width="577" alt="image" src="https://github.com/user-attachments/assets/69b48709-7bd8-4ee3-b886-db736ad75d77" />
