### PR TITLE
feat: aggregate from preloaded stream

### DIFF
--- a/api/skulpture-eventing/src/skulpture_eventing/entity/core.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/entity/core.clj
@@ -24,13 +24,15 @@
   ([entity transformer {:keys [committed-events uncommitted-events] :as _opts}]
    {:pre [(and (truss/have? keyword? entity)
                (truss/have? #(or (nil? %)
-                                 (empty %)
+                                 (empty? %)
                                  (and (seq %)
+                                      (vector? %)
                                       (apply/valid-stream? %))) committed-events)
                (truss/have? #(or (nil? %)
-                                 (empty %)
+                                 (empty? %)
                                  (and (seq %)
-                                      (apply/valid-stream? %))) uncommitted-events)
+                                      (vector? %)
+                                      (every? es/event? %))) uncommitted-events)
                (truss/have? fn? transformer))]}
    (when (or (and (some? committed-events) (not-empty committed-events))
              (and (some? uncommitted-events) (not-empty uncommitted-events)))

--- a/api/skulpture-eventing/src/skulpture_eventing/entity/core.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/entity/core.clj
@@ -21,6 +21,23 @@
    An aggregate is composed of: the current state of the entity, events which have been committed and uncommitted events
    which have been applied to determine the current state. Expects a vector when events to apply are specified as
    order is important"
+  ([entity transformer {:keys [committed-events uncommitted-events] :as _opts}]
+   {:pre [(and (truss/have? keyword? entity)
+               (truss/have? #(or (nil? %)
+                                 (empty %)
+                                 (and (seq %)
+                                      (apply/valid-stream? %))) committed-events)
+               (truss/have? #(or (nil? %)
+                                 (empty %)
+                                 (and (seq %)
+                                      (apply/valid-stream? %))) uncommitted-events)
+               (truss/have? fn? transformer))]}
+   (when (or (and (some? committed-events) (not-empty committed-events))
+             (and (some? uncommitted-events) (not-empty uncommitted-events)))
+     (let [current-state (apply/aggregate transformer (into [] cat [committed-events uncommitted-events]))
+           schema (truss/have ((keyword entity)  @schema-registry))]
+       (when (truss/have (partial s/valid? schema) current-state)
+         {:aggregate current-state :events committed-events :uncommitted-events uncommitted-events}))))
   ([connectable entity entity-id transformer]
    {:pre [(and (truss/have? #(satisfies? jdbc-protocols/Connectable %) connectable)
                (truss/have? keyword? entity)

--- a/api/skulpture-eventing/src/skulpture_eventing/entity/core_test.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/entity/core_test.clj
@@ -74,7 +74,27 @@
                              :a (assoc acc :a (/ (get-in event [:event-data :a]) (or (:a acc) 1)))
                              :b (assoc acc :b (/ (get-in event [:event-data :b])  (or (:b acc) 1))))))
             aggregate (entity/aggregate (:ds-opts @db-mock/db) ::test 1 transformer)]
-        (t/is (= (:aggregate aggregate) {:a 2 :b 2 :revision 4})))))
+        (t/is (= (:aggregate aggregate) {:a 2 :b 2 :revision 4}))))
+    (t/testing "from specified event stream"
+      (let [committed-events [(create-event {:type :a :a 1} 1)
+                              (create-event {:type :b :b -1} 2)
+                              (create-event {:type :a :a 2} 3)
+                              (create-event {:type :b :b -2} 4)]
+            uncommitted-events [(create-event {:type :a :a 1} 5)
+                                (create-event {:type :b :b -1} 6)
+                                (create-event {:type :a :a 2} 7)
+                                (create-event {:type :b :b -2} 8)]
+            transformer (fn
+                          ([] {})
+                          ([acc] acc)
+                          ([acc {{:keys [type]} :event-data :as event}]
+                           (case type
+                             :a (assoc acc :a (/ (get-in event [:event-data :a]) (or (:a acc) 1)))
+                             :b (assoc acc :b (/ (get-in event [:event-data :b])  (or (:b acc) 1))))))
+            aggregate (entity/aggregate ::test transformer {:committed-events committed-events
+                                                            :uncommitted-events uncommitted-events})]
+        (t/is (= (:aggregate aggregate) {:a 4 :b 4 :revision 8}))
+        (t/is (= (:uncommitted-events aggregate) uncommitted-events)))))
   (t/testing "applies uncommitted events"
     (with-redefs [store/load-by-entity-id (constantly [(create-event {:type :a :a 1} 1)
                                                        (create-event {:type :b :b -1} 2)

--- a/api/skulpture-eventing/src/skulpture_eventing/entity/core_test.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/entity/core_test.clj
@@ -60,7 +60,23 @@
                      (entity/aggregate (:ds-opts @db-mock/db) ::test (entity/aggregate (:ds-opts @db-mock/db) ::test 1234 transformer) transformer []))))
         (t/testing "vector uncommitted events"
           (t/is (and (truss/throws? (entity/aggregate (:ds-opts @db-mock/db) ::test (entity/aggregate (:ds-opts @db-mock/db) ::test 1234 transformer) transformer '()))
-                     (entity/aggregate (:ds-opts @db-mock/db) ::test (entity/aggregate (:ds-opts @db-mock/db) ::test 1234 transformer) transformer [])))))))
+                     (entity/aggregate (:ds-opts @db-mock/db) ::test (entity/aggregate (:ds-opts @db-mock/db) ::test 1234 transformer) transformer []))))
+        (t/testing "from specified event stream options"
+          (t/testing "committed events"
+            (t/is (and (truss/throws? (entity/aggregate ::test transformer {:committed-events '((create-event {:type :a :a 1} 1)) ;; must be a vector
+                                                                            :uncommitted-events [(create-event {:type :b :b -1} 2)]}))
+                       (truss/throws? (entity/aggregate ::test transformer {:committed-events [(create-event {:type :a :a 1} 2)] ;; invalid stream
+                                                                            :uncommitted-events [{:type :b :b -1}]}))
+                       (entity/aggregate ::test transformer {:committed-events [(create-event {:type :a :a 1} 1)] ;; valid
+                                                             :uncommitted-events [(create-event {:type :b :b -1} 2)]}))))
+          (t/testing "uncommitted events"
+            (t/is (and (truss/throws? (entity/aggregate ::test transformer {:committed-events [(create-event {:type :a :a 1} 1)]
+                                                                            :uncommitted-events '((create-event {:type :b :b -1} 2))})) ;; must be a vector
+                       (truss/throws? (entity/aggregate ::test transformer {:committed-events [(create-event {:type :a :a 1} 1)]
+                                                                            :uncommitted-events [{:type :b :b -1}]})) ;; invalid event
+                       ;; valid
+                       (entity/aggregate ::test transformer {:committed-events [(create-event {:type :a :a 1} 1)]
+                                                             :uncommitted-events [(create-event {:type :b :b -1} 2)]}))))))))
   (t/testing "returns current state"
     (with-redefs [store/load-by-entity-id (constantly [(create-event {:type :a :a 1} 1)
                                                        (create-event {:type :b :b -1} 2)

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core.clj
@@ -1,9 +1,8 @@
 (ns skulpture-eventing.store.core
-  (:require [clj-uuid :as uuid]
-            [honey.sql :as sql]
+  (:require [honey.sql :as sql]
             [next.jdbc :as jdbc]
-            [java-time.api :as jt]
-            [skulpture-eventing.store.agents :as agents]))
+            [skulpture-eventing.store.agents :as agents]
+            [skulpture-eventing.store.transformers :as transformers]))
 
 (defn load-by-entity-id
   "Load all events for an entity by its id.
@@ -131,16 +130,10 @@
 (defn persist!
   "Persist a stream of events"
   [connectable events]
-  (let [row-mapper #(vector (:event-agent %)
-                            (str (or (:entity-id %) (uuid/v7)))
-                            (or (:time-occurred %) (jt/instant))
-                            (:time-observed %)
-                            [:lift (:event-data %)]
-                            (:revision %))
-        query! (-> {:insert-into [:event-journal]
+  (let [query! (-> {:insert-into [:event-journal]
                     :columns [:event-agent :entity-id :time-occurred :time-observed :event-data :revision]
-                    :values (map row-mapper events)
+                    :values (map transformers/->sql-value events)
                     :returning :*}
-                   (sql/format {:params {:events events}}))
+                   (sql/format))
         result (jdbc/execute! connectable query!)]
     result))

--- a/api/skulpture-eventing/src/skulpture_eventing/store/transformers.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/transformers.clj
@@ -1,0 +1,10 @@
+(ns skulpture-eventing.store.transformers
+  (:require [clj-uuid :as uuid]
+            [java-time.api :as jt]))
+
+(def ->sql-value  #(vector (:event-agent %)
+                           (str (or (:entity-id %) (uuid/v7)))
+                           (or (:time-occurred %) (jt/instant))
+                           (:time-observed %)
+                           [:lift (:event-data %)]
+                           (:revision %)))


### PR DESCRIPTION
allows `aggregate` to be used with event streams returned by `load-by-entity-ids` and `load-by-entity-id-and-revision`