### PR TITLE
fix: rearrange routes again

### DIFF
--- a/api/imigresen-api/src/imigresen_api/api/v1/im42.clj
+++ b/api/imigresen-api/src/imigresen_api/api/v1/im42.clj
@@ -9,104 +9,105 @@
             [imigresen-common.components.user.store :as imi-user]))
 
 (defn im42-routes []
-  ["/user/:user-uuid/im42" {:tags ["im42.v1"]}
-   ["" {:post {:summary "Register a new IM42 form"
-               :handler (fn [{:keys [identity parameters] :as _req}]
-                          (-> (imi-im42/register-im42-form!
-                               identity
-                               (truss/have imi-user/active-by-uuid?
-                                           (get-in parameters [:path :user-uuid])
-                                           :data {:type :not-found})
-                               (get-in parameters [:body :automerge-url]))
-                              (ring-res/response)
-                              (ring-res/content-type (:plain-text imi-routes/content-types))
-                              (ring-res/status (:created imi-routes/status-codes))))
-               :parameters {:path {:user-uuid ::imi-im42-spec/uuid}
-                            :body (ds/spec {:name ::post-register
-                                            :spec {:automerge-url ::imi-im42-spec/automerge-url}})}
-               :responses {(:created imi-routes/status-codes) {:description "Created"
-                                                               :body uuid?}
-                           (:not-found imi-routes/status-codes) {:description "Not found"}
-                           (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
-                           (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
-               :middleware [imi-auth/protect]}}]
-   ["/config/synced" {:put {:summary "Mark a user as synced"
-                            :handler (fn [{:keys [identity parameters] :as _req}]
-                                       (imi-im42/synced! identity
-                                                         (truss/have imi-user/active-by-uuid?
-                                                                     (get-in parameters [:path :user-uuid])
-                                                                     :data {:type :not-found}))
-                                       (-> (ring-res/response nil)
-                                           (ring-res/status (:no-content imi-routes/status-codes))))
-                            :parameters {:path {:user-uuid ::imi-im42-spec/uuid}}
-                            :responses {(:no-content imi-routes/status-codes) {:description "No content"
-                                                                               :body vector?}
-                                        (:not-found imi-routes/status-codes) {:description "Not found"}
-                                        (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
-                                        (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
-                            :middleware [imi-auth/protect]}}]
+  ["/im42" {:tags ["im42.v1"]}
+   ["/user/:user-uuid"
+    ["" {:post {:summary "Register a new IM42 form"
+                :handler (fn [{:keys [identity parameters] :as _req}]
+                           (-> (imi-im42/register-im42-form!
+                                identity
+                                (truss/have imi-user/active-by-uuid?
+                                            (get-in parameters [:path :user-uuid])
+                                            :data {:type :not-found})
+                                (get-in parameters [:body :automerge-url]))
+                               (ring-res/response)
+                               (ring-res/content-type (:plain-text imi-routes/content-types))
+                               (ring-res/status (:created imi-routes/status-codes))))
+                :parameters {:path {:user-uuid ::imi-im42-spec/uuid}
+                             :body (ds/spec {:name ::post-register
+                                             :spec {:automerge-url ::imi-im42-spec/automerge-url}})}
+                :responses {(:created imi-routes/status-codes) {:description "Created"
+                                                                :body uuid?}
+                            (:not-found imi-routes/status-codes) {:description "Not found"}
+                            (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
+                            (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
+                :middleware [imi-auth/protect]}}]
+    ["/config/synced" {:put {:summary "Mark a user as synced"
+                             :handler (fn [{:keys [identity parameters] :as _req}]
+                                        (imi-im42/synced! identity
+                                                          (truss/have imi-user/active-by-uuid?
+                                                                      (get-in parameters [:path :user-uuid])
+                                                                      :data {:type :not-found}))
+                                        (-> (ring-res/response nil)
+                                            (ring-res/status (:no-content imi-routes/status-codes))))
+                             :parameters {:path {:user-uuid ::imi-im42-spec/uuid}}
+                             :responses {(:no-content imi-routes/status-codes) {:description "No content"
+                                                                                :body vector?}
+                                         (:not-found imi-routes/status-codes) {:description "Not found"}
+                                         (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
+                                         (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
+                             :middleware [imi-auth/protect]}}]]
    ;; draft forms are stored in automerge repo until submitted
    ;; so all we store is an automerge url no data
-   ["/status/draft" {:get {:summary "Get draft IM42 forms"
-                           :description "Returns a sorted list of IM42 UUIDs to automerge urls, sort: desc time registered"
-                           :handler (fn [{:keys [parameters] :as _req}]
-                                      (-> (imi-im42/get-draft-im42-forms-by-user-uuid
-                                           (truss/have imi-user/active-by-uuid?
-                                                       (get-in parameters [:path :user-uuid])
-                                                       :data {:type :not-found}))
-                                          (ring-res/response)
-                                          (ring-res/status (:ok imi-routes/status-codes))))
-                           :parameters {:path {:user-uuid ::imi-im42-spec/uuid}}
-                           :responses {(:ok imi-routes/status-codes) {:description "Ok"
-                                                                      :body vector?}
-                                       (:not-found imi-routes/status-codes) {:description "Not found"}
-                                       (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
-                                       (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
-                           :middleware [imi-auth/protect]}}]
-   ["/:uuid" {:put {:summary "Update a registered IM42 form"
-                    :handler (fn [{:keys [identity parameters] :as _req}]
-                               (truss/have
-                                (imi-im42/upsert-im42-form!
-                                 identity
-                                 (truss/have imi-user/active-by-uuid?
-                                             (get-in parameters [:path :user-uuid])
-                                             :data {:type :not-found})
-                                 (truss/have #(imi-im42/creator-by-user-uuid? (get-in parameters [:path :user-uuid]) %)
-                                             (get-in parameters [:path :uuid])
-                                             :data {:type :not-found})
-                                 (:body parameters)))
-                               (-> (ring-res/response nil)
-                                   (ring-res/status (:no-content imi-routes/status-codes))))
-                    :parameters {:path {:user-uuid ::imi-im42-spec/uuid
-                                        :uuid ::imi-im42-spec/uuid}
-                                 :body (-> imi-im42-spec/im42-form
-                                           (update-in [:spec] dissoc :uuid)
-                                           (assoc :name ::put-im42-form)
-                                           (ds/spec))}
-                    :responses {(:no-content imi-routes/status-codes) {:description "No content"}
-                                (:not-found imi-routes/status-codes) {:description "Not found"}
-                                (:bad-request imi-routes/status-codes) {:description "Bad request"}
-                                (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
-                                (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
-                    :middleware [imi-auth/protect]}
-              :delete {:summary "Delete a registered IM42 form"
-                       :handler (fn [{:keys [identity parameters] :as _req}]
-                                  (truss/have
-                                   (imi-im42/delete-im42-form!
-                                    identity
-                                    (truss/have imi-user/active-by-uuid?
-                                                (get-in parameters [:path :user-uuid])
-                                                :data {:type :not-found})
-                                    (truss/have #(imi-im42/creator-by-user-uuid? (get-in parameters [:path :user-uuid]) %)
-                                                (get-in parameters [:path :uuid])
-                                                :data {:type :not-found})))
-                                  (-> (ring-res/response nil)
-                                      (ring-res/status (:no-content imi-routes/status-codes))))
-                       :parameters {:path {:user-uuid ::imi-im42-spec/uuid
-                                           :uuid ::imi-im42-spec/uuid}}
-                       :responses {(:no-content imi-routes/status-codes) {:description "No content"}
-                                   (:not-found imi-routes/status-codes) {:description "Not found"}
-                                   (:bad-request imi-routes/status-codes) {:description "Bad request"}
-                                   (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
-                                   (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
-                       :middleware [imi-auth/protect]}}]])
+   ["/draft/user/:user-uuid" {:get {:summary "Get draft IM42 forms"
+                                    :description "Returns a sorted list of IM42 UUIDs to automerge urls, sort: desc time registered"
+                                    :handler (fn [{:keys [parameters] :as _req}]
+                                               (-> (imi-im42/get-draft-im42-forms-by-user-uuid
+                                                    (truss/have imi-user/active-by-uuid?
+                                                                (get-in parameters [:path :user-uuid])
+                                                                :data {:type :not-found}))
+                                                   (ring-res/response)
+                                                   (ring-res/status (:ok imi-routes/status-codes))))
+                                    :parameters {:path {:user-uuid ::imi-im42-spec/uuid}}
+                                    :responses {(:ok imi-routes/status-codes) {:description "Ok"
+                                                                               :body vector?}
+                                                (:not-found imi-routes/status-codes) {:description "Not found"}
+                                                (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
+                                                (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
+                                    :middleware [imi-auth/protect]}}]
+   ["/:uuid/user/:user-uuid" {:put {:summary "Update a registered IM42 form"
+                                    :handler (fn [{:keys [identity parameters] :as _req}]
+                                               (truss/have
+                                                (imi-im42/upsert-im42-form!
+                                                 identity
+                                                 (truss/have imi-user/active-by-uuid?
+                                                             (get-in parameters [:path :user-uuid])
+                                                             :data {:type :not-found})
+                                                 (truss/have #(imi-im42/creator-by-user-uuid? (get-in parameters [:path :user-uuid]) %)
+                                                             (get-in parameters [:path :uuid])
+                                                             :data {:type :not-found})
+                                                 (:body parameters)))
+                                               (-> (ring-res/response nil)
+                                                   (ring-res/status (:no-content imi-routes/status-codes))))
+                                    :parameters {:path {:user-uuid ::imi-im42-spec/uuid
+                                                        :uuid ::imi-im42-spec/uuid}
+                                                 :body (-> imi-im42-spec/im42-form
+                                                           (update-in [:spec] dissoc :uuid)
+                                                           (assoc :name ::put-im42-form)
+                                                           (ds/spec))}
+                                    :responses {(:no-content imi-routes/status-codes) {:description "No content"}
+                                                (:not-found imi-routes/status-codes) {:description "Not found"}
+                                                (:bad-request imi-routes/status-codes) {:description "Bad request"}
+                                                (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
+                                                (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
+                                    :middleware [imi-auth/protect]}
+                              :delete {:summary "Delete a registered IM42 form"
+                                       :handler (fn [{:keys [identity parameters] :as _req}]
+                                                  (truss/have
+                                                   (imi-im42/delete-im42-form!
+                                                    identity
+                                                    (truss/have imi-user/active-by-uuid?
+                                                                (get-in parameters [:path :user-uuid])
+                                                                :data {:type :not-found})
+                                                    (truss/have #(imi-im42/creator-by-user-uuid? (get-in parameters [:path :user-uuid]) %)
+                                                                (get-in parameters [:path :uuid])
+                                                                :data {:type :not-found})))
+                                                  (-> (ring-res/response nil)
+                                                      (ring-res/status (:no-content imi-routes/status-codes))))
+                                       :parameters {:path {:user-uuid ::imi-im42-spec/uuid
+                                                           :uuid ::imi-im42-spec/uuid}}
+                                       :responses {(:no-content imi-routes/status-codes) {:description "No content"}
+                                                   (:not-found imi-routes/status-codes) {:description "Not found"}
+                                                   (:bad-request imi-routes/status-codes) {:description "Bad request"}
+                                                   (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
+                                                   (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
+                                       :middleware [imi-auth/protect]}}]])

--- a/api/imigresen-api/src/imigresen_api/api/v1/im42.clj
+++ b/api/imigresen-api/src/imigresen_api/api/v1/im42.clj
@@ -48,22 +48,22 @@
                              :middleware [imi-auth/protect]}}]]
    ;; draft forms are stored in automerge repo until submitted
    ;; so all we store is an automerge url no data
-   ["/draft/user/:user-uuid" {:get {:summary "Get draft IM42 forms"
-                                    :description "Returns a sorted list of IM42 UUIDs to automerge urls, sort: desc time registered"
-                                    :handler (fn [{:keys [parameters] :as _req}]
-                                               (-> (imi-im42/get-draft-im42-forms-by-user-uuid
-                                                    (truss/have imi-user/active-by-uuid?
-                                                                (get-in parameters [:path :user-uuid])
-                                                                :data {:type :not-found}))
-                                                   (ring-res/response)
-                                                   (ring-res/status (:ok imi-routes/status-codes))))
-                                    :parameters {:path {:user-uuid ::imi-im42-spec/uuid}}
-                                    :responses {(:ok imi-routes/status-codes) {:description "Ok"
-                                                                               :body vector?}
-                                                (:not-found imi-routes/status-codes) {:description "Not found"}
-                                                (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
-                                                (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
-                                    :middleware [imi-auth/protect]}}]
+   ["/status/draft/user/:user-uuid" {:get {:summary "Get draft IM42 forms"
+                                           :description "Returns a sorted list of IM42 UUIDs to automerge urls, sort: desc time registered"
+                                           :handler (fn [{:keys [parameters] :as _req}]
+                                                      (-> (imi-im42/get-draft-im42-forms-by-user-uuid
+                                                           (truss/have imi-user/active-by-uuid?
+                                                                       (get-in parameters [:path :user-uuid])
+                                                                       :data {:type :not-found}))
+                                                          (ring-res/response)
+                                                          (ring-res/status (:ok imi-routes/status-codes))))
+                                           :parameters {:path {:user-uuid ::imi-im42-spec/uuid}}
+                                           :responses {(:ok imi-routes/status-codes) {:description "Ok"
+                                                                                      :body vector?}
+                                                       (:not-found imi-routes/status-codes) {:description "Not found"}
+                                                       (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
+                                                       (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
+                                           :middleware [imi-auth/protect]}}]
    ["/:uuid/user/:user-uuid" {:put {:summary "Update a registered IM42 form"
                                     :handler (fn [{:keys [identity parameters] :as _req}]
                                                (truss/have

--- a/api/imigresen-api/src/imigresen_api/api/v1/personal_details.clj
+++ b/api/imigresen-api/src/imigresen_api/api/v1/personal_details.clj
@@ -10,39 +10,40 @@
             [taoensso.truss :as truss]))
 
 (defn personal-details-routes []
-  ["/user/:user-uuid/personal-details" {:tags ["personal-details.v1"]}
-   ["" {:get {:summary "Get personal details by user UUID"
-              :handler (fn [{:keys [parameters] :as _req}]
-                         (-> (truss/have imi-user/active-by-uuid? (get-in parameters [:path :user-uuid]) :data {:type :not-found})
-                             (imi-pd/get-personal-details-by-user-uuid)
-                             (ring-res/response)
-                             (ring-res/status (:ok imi-routes/status-codes))))
-              :parameters {:path {:user-uuid ::imi-user-spec/uuid}}
-              :responses {(:ok imi-routes/status-codes) {:description "Ok"
-                                                         :body (ds/spec imi-pd-spec/personal-details)}
-                          (:not-found imi-routes/status-codes) {:description "Not found"}
-                          (:bad-request imi-routes/status-codes) {:description "Bad request"}
-                          (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
-                          (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
-              :middleware [imi-auth/protect]}
-        :put {:summary "Update personal details by user UUID"
-              :handler (fn [{:keys [identity parameters] :as _req}]
-                         (-> (:body parameters)
-                             (assoc :user-uuid
-                                    (truss/have imi-user/active-by-uuid? (get-in parameters [:path :user-uuid])) :data {:type :not-found})
-                             ((partial imi-pd/upsert-by-user-uuid! identity))
-                             (truss/have))
-                         (-> (ring-res/response nil)
-                             (ring-res/status (:no-content imi-routes/status-codes))))
-              :parameters {:path {:user-uuid ::imi-user-spec/uuid}
-                           :body (ds/spec {:name ::put-user-personal-details
-                                           :spec (-> imi-pd-spec/personal-details
-                                                     (update-in [:spec] dissoc :uuid)
-                                                     (assoc :name ::put-personal-details)
-                                                     (ds/spec))})}
-              :responses {(:no-content imi-routes/status-codes) {:description "No content"}
-                          (:not-found imi-routes/status-codes) {:description "Not found"}
-                          (:bad-request imi-routes/status-codes) {:description "Bad request"}
-                          (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
-                          (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
-              :middleware [imi-auth/protect]}}]])
+  ["/personal-details" {:tags ["personal-details.v1"]}
+   ["/user/:user-uuid"
+    ["" {:get {:summary "Get personal details by user UUID"
+               :handler (fn [{:keys [parameters] :as _req}]
+                          (-> (truss/have imi-user/active-by-uuid? (get-in parameters [:path :user-uuid]) :data {:type :not-found})
+                              (imi-pd/get-personal-details-by-user-uuid)
+                              (ring-res/response)
+                              (ring-res/status (:ok imi-routes/status-codes))))
+               :parameters {:path {:user-uuid ::imi-user-spec/uuid}}
+               :responses {(:ok imi-routes/status-codes) {:description "Ok"
+                                                          :body (ds/spec imi-pd-spec/personal-details)}
+                           (:not-found imi-routes/status-codes) {:description "Not found"}
+                           (:bad-request imi-routes/status-codes) {:description "Bad request"}
+                           (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
+                           (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
+               :middleware [imi-auth/protect]}
+         :put {:summary "Update personal details by user UUID"
+               :handler (fn [{:keys [identity parameters] :as _req}]
+                          (-> (:body parameters)
+                              (assoc :user-uuid
+                                     (truss/have imi-user/active-by-uuid? (get-in parameters [:path :user-uuid])) :data {:type :not-found})
+                              ((partial imi-pd/upsert-by-user-uuid! identity))
+                              (truss/have))
+                          (-> (ring-res/response nil)
+                              (ring-res/status (:no-content imi-routes/status-codes))))
+               :parameters {:path {:user-uuid ::imi-user-spec/uuid}
+                            :body (ds/spec {:name ::put-user-personal-details
+                                            :spec (-> imi-pd-spec/personal-details
+                                                      (update-in [:spec] dissoc :uuid)
+                                                      (assoc :name ::put-personal-details)
+                                                      (ds/spec))})}
+               :responses {(:no-content imi-routes/status-codes) {:description "No content"}
+                           (:not-found imi-routes/status-codes) {:description "Not found"}
+                           (:bad-request imi-routes/status-codes) {:description "Bad request"}
+                           (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
+                           (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
+               :middleware [imi-auth/protect]}}]]])


### PR DESCRIPTION
rearranging routes again so that we can utilise this pattern client side:
<img width="468" height="117" alt="image" src="https://github.com/user-attachments/assets/56ce685d-e889-4e59-9dab-f424161ed0a3" />

other notes:
- a route like `/im42/:uuid/user/:user-uuid` to get im42 form details by uuid looked odd at first but thought about it and it makes sense?
   - if visibility of form fields were conditional then depending on the `user-uuid` we would get inaccessible fields blanked out
