### PR TITLE
feat: scaffold POST /user/:uuid/avatar endpoint

### DIFF
--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -64,7 +64,13 @@
                                   [org.testcontainers/postgresql "1.21.2"]
                                   ;; not required for dev, its only used in tests but
                                   ;; hmr throws without it
-                                  [ring/ring-mock "0.6.1"]]}
+                                  [ring/ring-mock "0.6.1"]
+                                  ;; AWS dependencies
+                                  [amazonica "0.3.168" :exclusions [com.amazonaws/aws-java-sdk
+                                                                     com.amazonaws/amazon-kinesis-client
+                                                                     com.amazonaws/dynamodb-lock-client]]
+                                  [com.amazonaws/aws-java-sdk-s3 "1.12.788"]
+                                  [com.amazonaws/aws-java-sdk-core "1.12.788"]]}
              :uberjar {:env {:java-env "production"}
                        :aot [imigresen-api.app.core]
                        ;; https://cljdoc.org/d/com.taoensso/telemere/1.0.1/api/taoensso.telemere.tools-logging#tools-logging-%3Etelemere!

--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -58,19 +58,19 @@
                                   [metosin/spec-tools "0.10.7"]
                                   [metosin/jsonista "0.3.13"]
                                   [io.randomseed/phone-number "8.13.6-3"]
+                                  ;; AWS dependencies
+                                  [amazonica "0.3.168" :exclusions [com.amazonaws/aws-java-sdk
+                                                                    com.amazonaws/amazon-kinesis-client
+                                                                    com.amazonaws/dynamodb-lock-client]]
+                                  [com.amazonaws/aws-java-sdk-s3 "1.12.788"]
+                                  [com.amazonaws/aws-java-sdk-core "1.12.788"]
                                   ;; imigresen-common test deps for checkout
                                   ;; hmr fails otherwise
                                   [clj-test-containers/clj-test-containers "0.7.4"]
                                   [org.testcontainers/postgresql "1.21.2"]
                                   ;; not required for dev, its only used in tests but
                                   ;; hmr throws without it
-                                  [ring/ring-mock "0.6.1"]
-                                  ;; AWS dependencies
-                                  [amazonica "0.3.168" :exclusions [com.amazonaws/aws-java-sdk
-                                                                     com.amazonaws/amazon-kinesis-client
-                                                                     com.amazonaws/dynamodb-lock-client]]
-                                  [com.amazonaws/aws-java-sdk-s3 "1.12.788"]
-                                  [com.amazonaws/aws-java-sdk-core "1.12.788"]]}
+                                  [ring/ring-mock "0.6.1"]]}
              :uberjar {:env {:java-env "production"}
                        :aot [imigresen-api.app.core]
                        ;; https://cljdoc.org/d/com.taoensso/telemere/1.0.1/api/taoensso.telemere.tools-logging#tools-logging-%3Etelemere!

--- a/api/imigresen-api/src/imigresen_api/api/v1/user.clj
+++ b/api/imigresen-api/src/imigresen_api/api/v1/user.clj
@@ -119,4 +119,4 @@
                                     (:bad-request imi-routes/status-codes) {:description "Bad request"}
                                     (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
                                     (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
-                        :middleware [imi-auth/protect]}}]]])
+                        :middleware [imi-auth/protect]}}]])

--- a/api/imigresen-api/src/imigresen_api/api/v1/user.clj
+++ b/api/imigresen-api/src/imigresen_api/api/v1/user.clj
@@ -119,4 +119,4 @@
                                     (:bad-request imi-routes/status-codes) {:description "Bad request"}
                                     (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
                                     (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
-                        :middleware [imi-auth/protect]}}]]])
+                        :middleware [imi-auth/protect]}}]]]])

--- a/api/imigresen-api/src/imigresen_api/api/v1/user.clj
+++ b/api/imigresen-api/src/imigresen_api/api/v1/user.clj
@@ -108,4 +108,15 @@
                                         (:not-found imi-routes/status-codes) {:description "Not found"}
                                         (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
                                         (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
-                            :middleware [imi-auth/protect]}}]]]])
+                            :middleware [imi-auth/protect]}}]
+     ["/avatar" {:post {:summary "Upsert user avatar"
+                        :handler (fn [{:keys [identity parameters] :as _req}]
+                                   (imi-user/upsert-avatar! identity (get-in parameters [:path :uuid]))
+                                   (-> (ring-res/response nil)
+                                       (ring-res/status (:no-content imi-routes/status-codes))))
+                        :parameters {:path {:uuid ::imi-user-spec/uuid}}
+                        :responses {(:no-content imi-routes/status-codes) {:description "No content"}
+                                    (:bad-request imi-routes/status-codes) {:description "Bad request"}
+                                    (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
+                                    (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
+                        :middleware [imi-auth/protect]}}]]])

--- a/api/imigresen-api/src/imigresen_api/api/v1/user.clj
+++ b/api/imigresen-api/src/imigresen_api/api/v1/user.clj
@@ -119,4 +119,4 @@
                                     (:bad-request imi-routes/status-codes) {:description "Bad request"}
                                     (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
                                     (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
-                        :middleware [imi-auth/protect]}}]])
+                        :middleware [imi-auth/protect]}}]]])

--- a/api/imigresen-api/src/imigresen_api/api/v1/user.clj
+++ b/api/imigresen-api/src/imigresen_api/api/v1/user.clj
@@ -109,7 +109,7 @@
                                         (:unauthorized imi-routes/status-codes) {:description "Unauthorized"}
                                         (:internal-server-error imi-routes/status-codes) {:description "Internal server error"}}
                             :middleware [imi-auth/protect]}}]
-     ["/avatar" {:post {:summary "Upsert user avatar"
+     ["/avatar" {:post {:summary "[TODO] Upsert user avatar"
                         :handler (fn [{:keys [identity parameters] :as _req}]
                                    (imi-user/upsert-avatar! identity (get-in parameters [:path :uuid]))
                                    (-> (ring-res/response nil)


### PR DESCRIPTION
- Add POST /user/:uuid/avatar endpoint with auth protection and swagger docs
- Endpoint calls imi-user/upsert-avatar! and returns no-content response
- Protected with imi-auth/protect middleware
- Includes proper swagger documentation with all required responses

Part of #337