### PR TITLE
chore: add CloudFlare R2 environment variables to dev docker compose

### DIFF
--- a/api/imigresen-api/docker-compose.dev.yml
+++ b/api/imigresen-api/docker-compose.dev.yml
@@ -57,6 +57,9 @@ services:
       POSTMARK_SERVER_TOKEN: ${POSTMARK_SERVER_TOKEN}
       POSTMARK_ACCOUNT_TOKEN: ${POSTMARK_ACCOUNT_TOKEN}
       JAVA_ENV: "development"
+      CF_R2_ACCESS_KEY: ${CF_R2_ACCESS_KEY}
+      CF_R2_SECRET_KEY: ${CF_R2_SECRET_KEY}
+      CF_R2_ENDPOINT: ${CF_R2_ENDPOINT}
     deploy:
       mode: replicated
       replicas: 2


### PR DESCRIPTION
Add CF_R2_ACCESS_KEY, CF_R2_SECRET_KEY, and CF_R2_ENDPOINT environment variables to the imigresen-api-dev service in docker-compose.dev.yml to enable CloudFlare R2 access.

Resolves #344