### PR TITLE
feat: i18n yup validation errors

### DIFF
--- a/client/src/core/data/yup/yup-form.ts
+++ b/client/src/core/data/yup/yup-form.ts
@@ -3,6 +3,7 @@ import type {
 	PartialValues,
 	ValidateForm,
 } from "@modular-forms/solid";
+import { getOwner, runWithOwner } from "solid-js";
 import { type Schema, type ValidationError } from "yup";
 import type { ValidateOptions } from "./types";
 
@@ -15,25 +16,29 @@ export const yupForm = <
 	schema: Schema<TType, TContext, TFieldValues>,
 	options?: ValidateOptions<TContext>,
 ): ValidateForm<TFieldValues> => {
-	return async (values: PartialValues<TFieldValues>) => {
-		const error: ValidationError | null = await schema
-			.validate(values, {
-				...options,
-				// if `abortEarly` then errors on only 1 field will show
-				// default behaviour: show all errors
-				abortEarly: options?.abortEarly ?? false,
-				get context() {
-					return options?.context();
-				},
-			})
-			.then(() => null)
-			.catch(error => {
-				if (options?.debug) {
-					console.error(error);
-				}
+	const owner = getOwner();
 
-				return error;
-			});
+	return async (values: PartialValues<TFieldValues>) => {
+		const error: ValidationError | null = await runWithOwner(owner, () =>
+			schema
+				.validate(values, {
+					...options,
+					// if `abortEarly` then errors on only 1 field will show
+					// default behaviour: show all errors
+					abortEarly: options?.abortEarly ?? false,
+					get context() {
+						return options?.context();
+					},
+				})
+				.then(() => null)
+				.catch(error => {
+					if (options?.debug) {
+						console.error(error);
+					}
+
+					return error;
+				}),
+		);
 
 		if (!error) {
 			return Object.create(null);

--- a/client/src/feat/profile/spec/user-details.ts
+++ b/client/src/feat/profile/spec/user-details.ts
@@ -1,10 +1,14 @@
 import { useI18n } from "core/context/i18n";
-import { resources } from "feat/profile/resources/i18n/en-us";
+import type { resources } from "feat/profile/resources/i18n/en-us";
 import { object, string } from "yup";
 import { constants } from "./constants";
 
 export const userDetailsSchema = object({
-	email: string().email(resources.form.errors.email),
+	email: string().email(() => {
+		const t = useI18n<typeof resources>();
+
+		return t("form.errors.email");
+	}),
 	firstName: string()
 		.min(constants.fieldConstraints.nameMinChars, () => {
 			const t = useI18n<typeof resources>();

--- a/client/src/feat/profile/spec/user-details.ts
+++ b/client/src/feat/profile/spec/user-details.ts
@@ -1,3 +1,4 @@
+import { useI18n } from "core/context/i18n";
 import { resources } from "feat/profile/resources/i18n/en-us";
 import { object, string } from "yup";
 import { constants } from "./constants";
@@ -5,37 +6,47 @@ import { constants } from "./constants";
 export const userDetailsSchema = object({
 	email: string().email(resources.form.errors.email),
 	firstName: string()
-		.min(
-			constants.fieldConstraints.nameMinChars,
-			resources.form.errors.minChars(
+		.min(constants.fieldConstraints.nameMinChars, () => {
+			const t = useI18n<typeof resources>();
+
+			return t(
+				"form.errors.minChars",
 				constants.fieldConstraints.nameMinChars,
-			),
-		)
-		.max(
-			constants.fieldConstraints.nameMaxChars,
-			resources.form.errors.maxChars(
+			);
+		})
+		.max(constants.fieldConstraints.nameMaxChars, () => {
+			const t = useI18n<typeof resources>();
+
+			return t(
+				"form.errors.maxChars",
 				constants.fieldConstraints.nameMaxChars,
-			),
-		)
-		.matches(
-			constants.regex.alphanumeric,
-			resources.form.errors.alphanumeric,
-		),
+			);
+		})
+		.matches(constants.regex.alphanumeric, () => {
+			const t = useI18n<typeof resources>();
+
+			return t("form.errors.alphanumeric");
+		}),
 	lastName: string()
-		.min(
-			constants.fieldConstraints.nameMinChars,
-			resources.form.errors.minChars(
+		.min(constants.fieldConstraints.nameMinChars, () => {
+			const t = useI18n<typeof resources>();
+
+			return t(
+				"form.errors.minChars",
 				constants.fieldConstraints.nameMinChars,
-			),
-		)
-		.max(
-			constants.fieldConstraints.nameMaxChars,
-			resources.form.errors.maxChars(
+			);
+		})
+		.max(constants.fieldConstraints.nameMaxChars, () => {
+			const t = useI18n<typeof resources>();
+
+			return t(
+				"form.errors.maxChars",
 				constants.fieldConstraints.nameMaxChars,
-			),
-		)
-		.matches(
-			constants.regex.alphanumeric,
-			resources.form.errors.alphanumeric,
-		),
+			);
+		})
+		.matches(constants.regex.alphanumeric, () => {
+			const t = useI18n<typeof resources>();
+
+			return t("form.errors.alphanumeric");
+		}),
 });


### PR DESCRIPTION
https://docs.solidjs.com/reference/reactive-utilities/run-with-owner

- `runWithOwner` allows the us to retrieve contexts from within the schema
- makes testing a little difficult but don't see a need to test the schema so, shouldn't be impossible just more setup work required

https://github.com/user-attachments/assets/1fb33b83-617c-4512-b7a0-70b4a983640e

