### PR TITLE
fix: profile details do not show updated details

### DIFF
--- a/client/src/core/constants/query-keys.ts
+++ b/client/src/core/constants/query-keys.ts
@@ -23,18 +23,4 @@ export const queryKeys = {
 		"getReferenceData",
 		token,
 	],
-	getUserProfile: (token?: string, email?: string) => [
-		"core",
-		"user",
-		"profile",
-		token,
-		email,
-	],
-	getUserPersonalDetails: (token?: string, uuid?: string) => [
-		"core",
-		"user",
-		"personalDetails",
-		token,
-		uuid,
-	],
 };

--- a/client/src/core/constants/query-keys.ts
+++ b/client/src/core/constants/query-keys.ts
@@ -23,4 +23,18 @@ export const queryKeys = {
 		"getReferenceData",
 		token,
 	],
+	getUserProfile: (token?: string, email?: string) => [
+		"core",
+		"user",
+		"profile",
+		token,
+		email,
+	],
+	getUserPersonalDetails: (token?: string, uuid?: string) => [
+		"core",
+		"user",
+		"personalDetails",
+		token,
+		uuid,
+	],
 };

--- a/client/src/core/constants/query-keys.ts
+++ b/client/src/core/constants/query-keys.ts
@@ -23,4 +23,18 @@ export const queryKeys = {
 		"getReferenceData",
 		token,
 	],
+	getUserDetails: (token?: string) => [
+		"core",
+		"context",
+		"user",
+		"getUserDetails",
+		token,
+	],
+	getPersonalDetails: (token?: string) => [
+		"core",
+		"context",
+		"user",
+		"getPersonalDetails",
+		token,
+	],
 };

--- a/client/src/core/context/index.tsx
+++ b/client/src/core/context/index.tsx
@@ -4,27 +4,42 @@ import { type Component, type ParentProps } from "solid-js";
 import { AuthnProvider } from "./authn";
 import { AuthzProvider } from "./authz";
 // import { FliptProviderMock as FliptProvider } from "./flipt";
+import { QueryClient, QueryClientProvider } from "@tanstack/solid-query";
 import { FliptProvider } from "./flipt";
 import { RouterProvider } from "./router";
 import { UiProvider } from "./ui";
 import { UserProvider } from "./user";
 
 export const Providers: Component<ParentProps> = props => {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: {
+				throwOnError: true,
+				suspense: true,
+			},
+			mutations: {
+				throwOnError: true,
+			},
+		},
+	});
+
 	return (
 		<MetaProvider>
-			<AuthnProvider>
-				<UserProvider>
-					<AuthzProvider>
-						<FliptProvider>
-							<RouterProvider>
-								<UiProvider>
-									<Shell>{props.children}</Shell>
-								</UiProvider>
-							</RouterProvider>
-						</FliptProvider>
-					</AuthzProvider>
-				</UserProvider>
-			</AuthnProvider>
+			<QueryClientProvider client={queryClient}>
+				<AuthnProvider>
+					<UserProvider>
+						<AuthzProvider>
+							<FliptProvider>
+								<RouterProvider>
+									<UiProvider>
+										<Shell>{props.children}</Shell>
+									</UiProvider>
+								</RouterProvider>
+							</FliptProvider>
+						</AuthzProvider>
+					</UserProvider>
+				</AuthnProvider>
+			</QueryClientProvider>
 		</MetaProvider>
 	);
 };

--- a/client/src/core/context/initializers.ts
+++ b/client/src/core/context/initializers.ts
@@ -26,7 +26,6 @@ export const createUiContext = (): UiSvc => ({
 	locale: "en-NZ",
 	theme: "dark",
 	mode: "default",
-	queryClient: null,
 	actions: {
 		init: noop,
 		setTheme: noop,

--- a/client/src/core/context/ui/provider-mock.tsx
+++ b/client/src/core/context/ui/provider-mock.tsx
@@ -1,5 +1,4 @@
 import { I18nProvider } from "@kobalte/core";
-import { QueryClient, QueryClientProvider } from "@tanstack/solid-query";
 import { AuthnContext } from "core/context/authn";
 import { useContext } from "core/context/utils";
 import { RepoContext } from "solid-automerge";
@@ -74,18 +73,13 @@ export const UiProviderMock: Component<
 		<UiContext.Provider value={withDefaultProps.svc}>
 			<Show when={!withDefaultProps.svc().isInitialLoading()}>
 				<RepoContext.Provider value={repo}>
-					<QueryClientProvider
-						client={
-							withDefaultProps.svc().queryClient as QueryClient
-						}>
-						<I18nProvider locale={withDefaultProps.svc().locale}>
-							{withDefaultProps.children}
+					<I18nProvider locale={withDefaultProps.svc().locale}>
+						{withDefaultProps.children}
 
-							<ToastRegion>
-								<ToastList />
-							</ToastRegion>
-						</I18nProvider>
-					</QueryClientProvider>
+						<ToastRegion>
+							<ToastList />
+						</ToastRegion>
+					</I18nProvider>
 				</RepoContext.Provider>
 			</Show>
 		</UiContext.Provider>

--- a/client/src/core/context/ui/provider.tsx
+++ b/client/src/core/context/ui/provider.tsx
@@ -1,6 +1,5 @@
 import { default as formbricks } from "@formbricks/js";
 import { I18nProvider } from "@kobalte/core/i18n";
-import { QueryClientProvider, type QueryClient } from "@tanstack/solid-query";
 import { AuthnContext } from "core/context/authn";
 import { createUiContext } from "core/context/initializers";
 import { useContext } from "core/context/utils";
@@ -90,16 +89,13 @@ export const UiProvider: Component<ParentProps> = props => {
 		<UiContext.Provider value={value}>
 			<Show when={!value().isInitialLoading()}>
 				<RepoContext.Provider value={repo}>
-					<QueryClientProvider
-						client={value().queryClient as QueryClient}>
-						<I18nProvider locale={value().locale}>
-							{props.children}
+					<I18nProvider locale={value().locale}>
+						{props.children}
 
-							<ToastRegion>
-								<ToastList />
-							</ToastRegion>
-						</I18nProvider>
-					</QueryClientProvider>
+						<ToastRegion>
+							<ToastList />
+						</ToastRegion>
+					</I18nProvider>
 				</RepoContext.Provider>
 			</Show>
 		</UiContext.Provider>

--- a/client/src/core/context/ui/store/index.ts
+++ b/client/src/core/context/ui/store/index.ts
@@ -1,6 +1,5 @@
-import { QueryClient } from "@tanstack/solid-query";
 import { AUTHN_SVC_SUB_CONFIG_KEY } from "core/context/authn";
-import { once, partialRight } from "es-toolkit";
+import { noop, once, partialRight } from "es-toolkit";
 import { createWithSignal } from "solid-zustand";
 import type { StateCreator } from "zustand";
 import {
@@ -20,7 +19,6 @@ export interface UiSvc {
 	locale: Locale;
 	theme: UiTheme;
 	mode: UiMode;
-	queryClient?: QueryClient | null;
 	actions: {
 		init: () => void;
 		setTheme: (theme: UiTheme) => void;
@@ -45,7 +43,6 @@ const persistLocalStorage: (
 	onRehydrateStorage: state => () => state.actions.setHasHydrated?.(),
 	partialize: state => {
 		const keysToIgnore: Set<keyof (UiSvc & UiSvcInternal)> = new Set([
-			"queryClient",
 			"actions",
 			"hasHydrated",
 		]);
@@ -62,8 +59,7 @@ const persistLocalStorage: (
 export const useStore = createWithSignal<UiSvc & UiSvcInternal>(
 	persistLocalStorage((set, get) => {
 		return {
-			isInitialLoading: () =>
-				Boolean(!get()?.hasHydrated || !get().queryClient),
+			isInitialLoading: () => Boolean(!get()?.hasHydrated),
 			locale: "en-NZ", // https://www.ietf.org/rfc/bcp/bcp47.txt
 			// TODO: There is a state update issue here
 			// if there is no persisted storage then `onRehydrateStorage`
@@ -72,23 +68,8 @@ export const useStore = createWithSignal<UiSvc & UiSvcInternal>(
 			hasHydrated: true,
 			theme: "dark" as UiTheme,
 			mode: "default" as UiMode,
-			queryClient: null,
 			actions: {
-				init: once(() => {
-					const queryClient = new QueryClient({
-						defaultOptions: {
-							queries: {
-								throwOnError: true,
-								suspense: true,
-							},
-							mutations: {
-								throwOnError: true,
-							},
-						},
-					});
-
-					set({ queryClient });
-				}),
+				init: once(noop),
 				setTheme: theme => set({ theme }),
 				setMode: mode => set({ mode }),
 				setHasHydrated: () => set({ hasHydrated: true }),

--- a/client/src/core/context/user/provider.tsx
+++ b/client/src/core/context/user/provider.tsx
@@ -3,7 +3,9 @@ import { createUserContext } from "core/context/initializers";
 import { useContext } from "core/context/utils";
 import {
 	createContext,
+	getOwner,
 	onMount,
+	runWithOwner,
 	Show,
 	type Accessor,
 	type Component,
@@ -16,9 +18,8 @@ export const UserContext = createContext<Accessor<UserSvc>>(createUserContext);
 export const UserProvider: Component<ParentProps> = props => {
 	const value = useStore();
 	const authnContext = useContext(AuthnContext);
+	const owner = getOwner();
 
-	// TODO: once BE is up properly this should not be dependent on `authn`
-	// `authn` just authenticates
 	onMount(() => {
 		if (authnContext().isInitialLoading) {
 			return;
@@ -26,7 +27,9 @@ export const UserProvider: Component<ParentProps> = props => {
 
 		const profile = authnContext().profile;
 
-		value().actions.init(authnContext().keycloak?.token, profile);
+		runWithOwner(owner, () =>
+			value().actions.init(authnContext().keycloak?.token, profile),
+		);
 	});
 
 	return (

--- a/client/src/core/context/user/provider.tsx
+++ b/client/src/core/context/user/provider.tsx
@@ -1,4 +1,5 @@
 import { AuthnContext } from "core/context/authn";
+import { UiContext } from "core/context/ui";
 import { createUserContext } from "core/context/initializers";
 import { useContext } from "core/context/utils";
 import {
@@ -16,6 +17,7 @@ export const UserContext = createContext<Accessor<UserSvc>>(createUserContext);
 export const UserProvider: Component<ParentProps> = props => {
 	const value = useStore();
 	const authnContext = useContext(AuthnContext);
+	const uiContext = useContext(UiContext);
 
 	// TODO: once BE is up properly this should not be dependent on `authn`
 	// `authn` just authenticates
@@ -25,8 +27,9 @@ export const UserProvider: Component<ParentProps> = props => {
 		}
 
 		const profile = authnContext().profile;
+		const queryClient = uiContext().queryClient;
 
-		value().actions.init(authnContext().keycloak?.token, profile);
+		value().actions.init(authnContext().keycloak?.token, profile, queryClient);
 	});
 
 	return (

--- a/client/src/core/context/user/provider.tsx
+++ b/client/src/core/context/user/provider.tsx
@@ -1,5 +1,4 @@
 import { AuthnContext } from "core/context/authn";
-import { UiContext } from "core/context/ui";
 import { createUserContext } from "core/context/initializers";
 import { useContext } from "core/context/utils";
 import {
@@ -17,7 +16,6 @@ export const UserContext = createContext<Accessor<UserSvc>>(createUserContext);
 export const UserProvider: Component<ParentProps> = props => {
 	const value = useStore();
 	const authnContext = useContext(AuthnContext);
-	const uiContext = useContext(UiContext);
 
 	// TODO: once BE is up properly this should not be dependent on `authn`
 	// `authn` just authenticates
@@ -27,9 +25,8 @@ export const UserProvider: Component<ParentProps> = props => {
 		}
 
 		const profile = authnContext().profile;
-		const queryClient = uiContext().queryClient;
 
-		value().actions.init(authnContext().keycloak?.token, profile, queryClient);
+		value().actions.init(authnContext().keycloak?.token, profile);
 	});
 
 	return (

--- a/client/src/core/context/user/store/index.ts
+++ b/client/src/core/context/user/store/index.ts
@@ -33,6 +33,7 @@ export interface UserSvc {
 	actions: {
 		init: (token?: string, profile?: KeycloakProfile | null) => void;
 		completeSync: (token?: string) => void;
+		refreshProfile: (token?: string, email?: string) => Promise<void>;
 	};
 }
 
@@ -115,6 +116,35 @@ export const useStore = createWithSignal<UserSvc>((set, get) => {
 					.put(`/user/${profile.uuid}/config/synced`);
 
 				set({ syncComplete: true });
+			},
+			refreshProfile: async (token?: string, email?: string) => {
+				if (!token || !email) {
+					return;
+				}
+
+				const searchParams = new URLSearchParams({
+					email,
+				});
+
+				const user = await userApi
+					.auth(`Bearer ${token}`)
+					.get(`?${searchParams.toString()}`)
+					.json<UserProfile>();
+
+				// Fetch personal details to get phone number
+				const personalDetails = await personalDetailsApi
+					.auth(`Bearer ${token}`)
+					.get(`/user/${user.uuid}`)
+					.notFound(() => null)
+					.json<UserPersonalDetails | null>();
+
+				// Update user profile with phone number from personal details
+				set({
+					profile: {
+						...user,
+						phoneNumber: personalDetails?.mobileNumber || "",
+					},
+				});
 			},
 		},
 	};

--- a/client/src/core/context/user/store/index.ts
+++ b/client/src/core/context/user/store/index.ts
@@ -1,7 +1,10 @@
+import { QueryClient } from "@tanstack/solid-query";
 import { invariant, once } from "es-toolkit";
 import type { KeycloakProfile } from "keycloak-js";
 import { createWithSignal } from "solid-zustand";
 import { default as wretch } from "wretch";
+import { queryKeys } from "core/constants/query-keys";
+import { profileService } from "feat/profile/services/profile-service";
 
 export interface UserProfile {
 	uuid: string;
@@ -31,9 +34,8 @@ export interface UserSvc {
 	profile?: UserProfile | null;
 	syncComplete?: boolean;
 	actions: {
-		init: (token?: string, profile?: KeycloakProfile | null) => void;
+		init: (token?: string, profile?: KeycloakProfile | null, queryClient?: QueryClient) => void;
 		completeSync: (token?: string) => void;
-		refreshProfile: (token?: string, email?: string) => Promise<void>;
 	};
 }
 
@@ -42,11 +44,7 @@ export interface IM42Config {
 	syncedAt?: Date | null;
 }
 
-const userApi = wretch(`${import.meta.env.VITE_API_BASE_URL}/user`);
 const im42Api = wretch(`${import.meta.env.VITE_API_BASE_URL}/im42`);
-const personalDetailsApi = wretch(
-	`${import.meta.env.VITE_API_BASE_URL}/personal-details`,
-);
 
 export const useStore = createWithSignal<UserSvc>((set, get) => {
 	return {
@@ -54,7 +52,7 @@ export const useStore = createWithSignal<UserSvc>((set, get) => {
 		profile: null,
 		actions: {
 			init: once(
-				async (token?: string, profile?: KeycloakProfile | null) => {
+				async (token?: string, profile?: KeycloakProfile | null, queryClient?: QueryClient) => {
 					if (!token || !profile) {
 						set({ isInitialLoading: false });
 
@@ -63,21 +61,23 @@ export const useStore = createWithSignal<UserSvc>((set, get) => {
 
 					invariant(profile.email, "No email for keycloak profile");
 
-					const searchParams = new URLSearchParams({
-						email: profile.email,
-					});
+					const service = profileService(token);
 
-					const user = await userApi
-						.auth(`Bearer ${token}`)
-						.get(`?${searchParams.toString()}`)
-						.json<UserProfile>();
+					// Use @tanstack/solid-query to fetch user profile
+					const user = queryClient 
+						? await queryClient.fetchQuery({
+							queryKey: queryKeys.getUserProfile(token, profile.email),
+							queryFn: () => service.getUserProfile(profile.email!),
+						})
+						: await service.getUserProfile(profile.email);
 
-					// Fetch personal details to get phone number
-					const personalDetails = await personalDetailsApi
-						.auth(`Bearer ${token}`)
-						.get(`/user/${user.uuid}`)
-						.notFound(() => null)
-						.json<UserPersonalDetails | null>();
+					// Use @tanstack/solid-query to fetch personal details
+					const personalDetails = queryClient
+						? await queryClient.fetchQuery({
+							queryKey: queryKeys.getUserPersonalDetails(token, user.uuid),
+							queryFn: () => service.getUserPersonalDetails(user.uuid),
+						})
+						: await service.getUserPersonalDetails(user.uuid);
 
 					// Update user profile with phone number from personal details
 					set({
@@ -87,7 +87,7 @@ export const useStore = createWithSignal<UserSvc>((set, get) => {
 						},
 					});
 
-					const im42Config = await userApi
+					const im42Config = await im42Api
 						.auth(`Bearer ${token}`)
 						.get(`/${user.uuid}/config/im42`)
 						// TODO: deep transform for responses
@@ -116,35 +116,6 @@ export const useStore = createWithSignal<UserSvc>((set, get) => {
 					.put(`/user/${profile.uuid}/config/synced`);
 
 				set({ syncComplete: true });
-			},
-			refreshProfile: async (token?: string, email?: string) => {
-				if (!token || !email) {
-					return;
-				}
-
-				const searchParams = new URLSearchParams({
-					email,
-				});
-
-				const user = await userApi
-					.auth(`Bearer ${token}`)
-					.get(`?${searchParams.toString()}`)
-					.json<UserProfile>();
-
-				// Fetch personal details to get phone number
-				const personalDetails = await personalDetailsApi
-					.auth(`Bearer ${token}`)
-					.get(`/user/${user.uuid}`)
-					.notFound(() => null)
-					.json<UserPersonalDetails | null>();
-
-				// Update user profile with phone number from personal details
-				set({
-					profile: {
-						...user,
-						phoneNumber: personalDetails?.mobileNumber || "",
-					},
-				});
 			},
 		},
 	};

--- a/client/src/core/context/user/store/index.ts
+++ b/client/src/core/context/user/store/index.ts
@@ -106,7 +106,11 @@ export const useStore = createWithSignal<UserSvc>((set, get) => {
 					}));
 
 					createEffect(() => {
-						if (!qUser.data || !qPersonalDetails.data) {
+						if (
+							qUser.isLoading ||
+							qPersonalDetails.isLoading ||
+							!qUser.data
+						) {
 							return;
 						}
 
@@ -131,9 +135,9 @@ export const useStore = createWithSignal<UserSvc>((set, get) => {
 
 					createEffect(() => {
 						if (
-							!qUser.data ||
-							!qPersonalDetails.data ||
-							!qIm42Config.data
+							qUser.isLoading ||
+							qPersonalDetails.isLoading ||
+							qIm42Config.isLoading
 						) {
 							return;
 						}

--- a/client/src/core/context/user/store/index.ts
+++ b/client/src/core/context/user/store/index.ts
@@ -1,10 +1,7 @@
-import { QueryClient } from "@tanstack/solid-query";
 import { invariant, once } from "es-toolkit";
 import type { KeycloakProfile } from "keycloak-js";
 import { createWithSignal } from "solid-zustand";
 import { default as wretch } from "wretch";
-import { queryKeys } from "core/constants/query-keys";
-import { profileService } from "feat/profile/services/profile-service";
 
 export interface UserProfile {
 	uuid: string;
@@ -34,8 +31,9 @@ export interface UserSvc {
 	profile?: UserProfile | null;
 	syncComplete?: boolean;
 	actions: {
-		init: (token?: string, profile?: KeycloakProfile | null, queryClient?: QueryClient) => void;
+		init: (token?: string, profile?: KeycloakProfile | null) => void;
 		completeSync: (token?: string) => void;
+		refreshProfile: (token?: string, email?: string) => Promise<void>;
 	};
 }
 
@@ -44,7 +42,11 @@ export interface IM42Config {
 	syncedAt?: Date | null;
 }
 
+const userApi = wretch(`${import.meta.env.VITE_API_BASE_URL}/user`);
 const im42Api = wretch(`${import.meta.env.VITE_API_BASE_URL}/im42`);
+const personalDetailsApi = wretch(
+	`${import.meta.env.VITE_API_BASE_URL}/personal-details`,
+);
 
 export const useStore = createWithSignal<UserSvc>((set, get) => {
 	return {
@@ -52,7 +54,7 @@ export const useStore = createWithSignal<UserSvc>((set, get) => {
 		profile: null,
 		actions: {
 			init: once(
-				async (token?: string, profile?: KeycloakProfile | null, queryClient?: QueryClient) => {
+				async (token?: string, profile?: KeycloakProfile | null) => {
 					if (!token || !profile) {
 						set({ isInitialLoading: false });
 
@@ -61,23 +63,21 @@ export const useStore = createWithSignal<UserSvc>((set, get) => {
 
 					invariant(profile.email, "No email for keycloak profile");
 
-					const service = profileService(token);
+					const searchParams = new URLSearchParams({
+						email: profile.email,
+					});
 
-					// Use @tanstack/solid-query to fetch user profile
-					const user = queryClient 
-						? await queryClient.fetchQuery({
-							queryKey: queryKeys.getUserProfile(token, profile.email),
-							queryFn: () => service.getUserProfile(profile.email!),
-						})
-						: await service.getUserProfile(profile.email);
+					const user = await userApi
+						.auth(`Bearer ${token}`)
+						.get(`?${searchParams.toString()}`)
+						.json<UserProfile>();
 
-					// Use @tanstack/solid-query to fetch personal details
-					const personalDetails = queryClient
-						? await queryClient.fetchQuery({
-							queryKey: queryKeys.getUserPersonalDetails(token, user.uuid),
-							queryFn: () => service.getUserPersonalDetails(user.uuid),
-						})
-						: await service.getUserPersonalDetails(user.uuid);
+					// Fetch personal details to get phone number
+					const personalDetails = await personalDetailsApi
+						.auth(`Bearer ${token}`)
+						.get(`/user/${user.uuid}`)
+						.notFound(() => null)
+						.json<UserPersonalDetails | null>();
 
 					// Update user profile with phone number from personal details
 					set({
@@ -87,7 +87,7 @@ export const useStore = createWithSignal<UserSvc>((set, get) => {
 						},
 					});
 
-					const im42Config = await im42Api
+					const im42Config = await userApi
 						.auth(`Bearer ${token}`)
 						.get(`/${user.uuid}/config/im42`)
 						// TODO: deep transform for responses
@@ -116,6 +116,35 @@ export const useStore = createWithSignal<UserSvc>((set, get) => {
 					.put(`/user/${profile.uuid}/config/synced`);
 
 				set({ syncComplete: true });
+			},
+			refreshProfile: async (token?: string, email?: string) => {
+				if (!token || !email) {
+					return;
+				}
+
+				const searchParams = new URLSearchParams({
+					email,
+				});
+
+				const user = await userApi
+					.auth(`Bearer ${token}`)
+					.get(`?${searchParams.toString()}`)
+					.json<UserProfile>();
+
+				// Fetch personal details to get phone number
+				const personalDetails = await personalDetailsApi
+					.auth(`Bearer ${token}`)
+					.get(`/user/${user.uuid}`)
+					.notFound(() => null)
+					.json<UserPersonalDetails | null>();
+
+				// Update user profile with phone number from personal details
+				set({
+					profile: {
+						...user,
+						phoneNumber: personalDetails?.mobileNumber || "",
+					},
+				});
 			},
 		},
 	};

--- a/client/src/core/context/user/store/index.ts
+++ b/client/src/core/context/user/store/index.ts
@@ -1,5 +1,8 @@
+import { useQuery } from "@tanstack/solid-query";
+import { queryKeys } from "core/constants/query-keys";
 import { invariant, once } from "es-toolkit";
 import type { KeycloakProfile } from "keycloak-js";
+import { createEffect } from "solid-js";
 import { createWithSignal } from "solid-zustand";
 import { default as wretch } from "wretch";
 
@@ -33,7 +36,6 @@ export interface UserSvc {
 	actions: {
 		init: (token?: string, profile?: KeycloakProfile | null) => void;
 		completeSync: (token?: string) => void;
-		refreshProfile: (token?: string, email?: string) => Promise<void>;
 	};
 }
 
@@ -67,42 +69,77 @@ export const useStore = createWithSignal<UserSvc>((set, get) => {
 						email: profile.email,
 					});
 
-					const user = await userApi
-						.auth(`Bearer ${token}`)
-						.get(`?${searchParams.toString()}`)
-						.json<UserProfile>();
+					const qUser = useQuery(() => ({
+						queryKey: queryKeys.getUserDetails(token),
+						queryFn: () =>
+							userApi
+								.auth(`Bearer ${token}`)
+								.get(`?${searchParams.toString()}`)
+								.json<UserProfile>(),
+					}));
 
-					// Fetch personal details to get phone number
-					const personalDetails = await personalDetailsApi
-						.auth(`Bearer ${token}`)
-						.get(`/user/${user.uuid}`)
-						.notFound(() => null)
-						.json<UserPersonalDetails | null>();
+					const qPersonalDetails = useQuery(() => ({
+						queryKey: queryKeys.getPersonalDetails(token),
+						queryFn: () =>
+							personalDetailsApi
+								.auth(`Bearer ${token}`)
+								.get(`/user/${qUser.data?.uuid}`)
+								.notFound(() => null)
+								.json<UserPersonalDetails | null>(),
+						enabled: Boolean(qUser.data),
+					}));
 
-					// Update user profile with phone number from personal details
-					set({
-						profile: {
-							...user,
-							phoneNumber: personalDetails?.mobileNumber || "",
-						},
+					const qIm42Config = useQuery(() => ({
+						queryKey: queryKeys.getPersonalDetails(token),
+						queryFn: () =>
+							userApi
+								.auth(`Bearer ${token}`)
+								.get(`/${qUser.data?.uuid}/config/im42`)
+								// TODO: deep transform for responses
+								.json<IM42Config>(res => ({
+									...res,
+									syncedAt: res.syncedAt
+										? new Date(res.syncedAt)
+										: null,
+								})),
+						enabled: Boolean(qUser.data),
+					}));
+
+					createEffect(() => {
+						if (!qUser.data || !qPersonalDetails.data) {
+							return;
+						}
+
+						set({
+							profile: {
+								...qUser.data,
+								phoneNumber:
+									qPersonalDetails.data?.mobileNumber || "",
+							},
+						});
 					});
 
-					const im42Config = await userApi
-						.auth(`Bearer ${token}`)
-						.get(`/${user.uuid}/config/im42`)
-						// TODO: deep transform for responses
-						.json<IM42Config>(res => ({
-							...res,
-							syncedAt: res.syncedAt
-								? new Date(res.syncedAt)
-								: null,
-						}));
+					createEffect(() => {
+						if (!qUser.data || !qIm42Config.data) {
+							return;
+						}
 
-					set({
-						syncComplete: Boolean(im42Config.syncedAt),
+						set({
+							syncComplete: Boolean(qIm42Config.data.syncedAt),
+						});
 					});
 
-					set({ isInitialLoading: false });
+					createEffect(() => {
+						if (
+							!qUser.data ||
+							!qPersonalDetails.data ||
+							!qIm42Config.data
+						) {
+							return;
+						}
+
+						set({ isInitialLoading: false });
+					});
 				},
 			),
 			completeSync: (token?: string) => {
@@ -116,35 +153,6 @@ export const useStore = createWithSignal<UserSvc>((set, get) => {
 					.put(`/user/${profile.uuid}/config/synced`);
 
 				set({ syncComplete: true });
-			},
-			refreshProfile: async (token?: string, email?: string) => {
-				if (!token || !email) {
-					return;
-				}
-
-				const searchParams = new URLSearchParams({
-					email,
-				});
-
-				const user = await userApi
-					.auth(`Bearer ${token}`)
-					.get(`?${searchParams.toString()}`)
-					.json<UserProfile>();
-
-				// Fetch personal details to get phone number
-				const personalDetails = await personalDetailsApi
-					.auth(`Bearer ${token}`)
-					.get(`/user/${user.uuid}`)
-					.notFound(() => null)
-					.json<UserPersonalDetails | null>();
-
-				// Update user profile with phone number from personal details
-				set({
-					profile: {
-						...user,
-						phoneNumber: personalDetails?.mobileNumber || "",
-					},
-				});
 			},
 		},
 	};

--- a/client/src/feat/profile/hooks/use-profile-form.ts
+++ b/client/src/feat/profile/hooks/use-profile-form.ts
@@ -1,6 +1,5 @@
 import { createForm, reset, type SubmitHandler } from "@modular-forms/solid";
-import { useMutation, useQueryClient } from "@tanstack/solid-query";
-import { queryKeys } from "core/constants/query-keys";
+import { useMutation } from "@tanstack/solid-query";
 import { AuthnContext } from "core/context/authn";
 import { UserContext } from "core/context/user";
 import { useContext } from "core/context/utils";
@@ -14,7 +13,6 @@ export const useProfileForm = () => {
 	const profileContext = useContext(ProfileContext);
 	const userContext = useContext(UserContext);
 	const authnContext = useContext(AuthnContext);
-	const queryClient = useQueryClient();
 
 	const [form, { Form, Field, FieldArray }] = createForm<ProfileForm>({
 		validateOn: "input",
@@ -29,18 +27,10 @@ export const useProfileForm = () => {
 		onSuccess: async () => {
 			const token = authnContext().keycloak?.token;
 			const profile = authnContext().profile;
-			const userProfile = userContext().profile;
 			
-			// Invalidate user profile queries to trigger refetch
+			// Refresh user profile data after successful update
 			if (token && profile?.email) {
-				await queryClient.invalidateQueries({
-					queryKey: queryKeys.getUserProfile(token, profile.email),
-				});
-			}
-			if (token && userProfile?.uuid) {
-				await queryClient.invalidateQueries({
-					queryKey: queryKeys.getUserPersonalDetails(token, userProfile.uuid),
-				});
+				await userContext().actions.refreshProfile(token, profile.email);
 			}
 		},
 	}));

--- a/client/src/feat/profile/hooks/use-profile-form.ts
+++ b/client/src/feat/profile/hooks/use-profile-form.ts
@@ -8,7 +8,7 @@ import { yupForm } from "core/data/yup/yup-form";
 import { ProfileContext } from "feat/profile/context";
 import { profileSchema } from "feat/profile/spec";
 import type { ProfileForm, UpdateProfilePayload } from "feat/profile/types";
-import { createEffect } from "solid-js";
+import { onMount } from "solid-js";
 
 export const useProfileForm = () => {
 	const profileContext = useContext(ProfileContext);
@@ -42,8 +42,9 @@ export const useProfileForm = () => {
 	}));
 
 	// Set default values when user profile is available
-	createEffect(() => {
+	onMount(() => {
 		const profile = userContext().profile;
+
 		if (profile) {
 			reset(form, {
 				initialValues: {

--- a/client/src/feat/profile/hooks/use-profile-form.ts
+++ b/client/src/feat/profile/hooks/use-profile-form.ts
@@ -1,5 +1,6 @@
 import { createForm, reset, type SubmitHandler } from "@modular-forms/solid";
 import { useMutation } from "@tanstack/solid-query";
+import { AuthnContext } from "core/context/authn";
 import { UserContext } from "core/context/user";
 import { useContext } from "core/context/utils";
 import { yupForm } from "core/data/yup/yup-form";
@@ -11,6 +12,7 @@ import { createEffect } from "solid-js";
 export const useProfileForm = () => {
 	const profileContext = useContext(ProfileContext);
 	const userContext = useContext(UserContext);
+	const authnContext = useContext(AuthnContext);
 
 	const [form, { Form, Field, FieldArray }] = createForm<ProfileForm>({
 		validateOn: "input",
@@ -22,6 +24,15 @@ export const useProfileForm = () => {
 	const mUpdateProfile = useMutation(() => ({
 		mutationFn: ({ values, uuid }: UpdateProfilePayload) =>
 			profileContext.updateProfile(values, uuid),
+		onSuccess: async () => {
+			const token = authnContext().keycloak?.token;
+			const profile = authnContext().profile;
+			
+			// Refresh user profile data after successful update
+			if (token && profile?.email) {
+				await userContext().actions.refreshProfile(token, profile.email);
+			}
+		},
 	}));
 
 	// Set default values when user profile is available

--- a/client/src/feat/profile/hooks/use-profile-form.ts
+++ b/client/src/feat/profile/hooks/use-profile-form.ts
@@ -1,5 +1,6 @@
 import { createForm, reset, type SubmitHandler } from "@modular-forms/solid";
-import { useMutation } from "@tanstack/solid-query";
+import { useMutation, useQueryClient } from "@tanstack/solid-query";
+import { queryKeys as globalQueryKeys } from "core/constants/query-keys";
 import { AuthnContext } from "core/context/authn";
 import { UserContext } from "core/context/user";
 import { useContext } from "core/context/utils";
@@ -12,6 +13,7 @@ import { createEffect } from "solid-js";
 export const useProfileForm = () => {
 	const profileContext = useContext(ProfileContext);
 	const userContext = useContext(UserContext);
+	const queryClient = useQueryClient();
 	const authnContext = useContext(AuthnContext);
 
 	const [form, { Form, Field, FieldArray }] = createForm<ProfileForm>({
@@ -25,13 +27,17 @@ export const useProfileForm = () => {
 		mutationFn: ({ values, uuid }: UpdateProfilePayload) =>
 			profileContext.updateProfile(values, uuid),
 		onSuccess: async () => {
-			const token = authnContext().keycloak?.token;
-			const profile = authnContext().profile;
-			
-			// Refresh user profile data after successful update
-			if (token && profile?.email) {
-				await userContext().actions.refreshProfile(token, profile.email);
-			}
+			queryClient.invalidateQueries({
+				queryKey: globalQueryKeys.getUserDetails(
+					authnContext().keycloak?.token,
+				),
+			});
+
+			queryClient.invalidateQueries({
+				queryKey: globalQueryKeys.getPersonalDetails(
+					authnContext().keycloak?.token,
+				),
+			});
 		},
 	}));
 

--- a/client/src/feat/profile/hooks/use-profile-form.ts
+++ b/client/src/feat/profile/hooks/use-profile-form.ts
@@ -1,5 +1,6 @@
 import { createForm, reset, type SubmitHandler } from "@modular-forms/solid";
-import { useMutation } from "@tanstack/solid-query";
+import { useMutation, useQueryClient } from "@tanstack/solid-query";
+import { queryKeys } from "core/constants/query-keys";
 import { AuthnContext } from "core/context/authn";
 import { UserContext } from "core/context/user";
 import { useContext } from "core/context/utils";
@@ -13,6 +14,7 @@ export const useProfileForm = () => {
 	const profileContext = useContext(ProfileContext);
 	const userContext = useContext(UserContext);
 	const authnContext = useContext(AuthnContext);
+	const queryClient = useQueryClient();
 
 	const [form, { Form, Field, FieldArray }] = createForm<ProfileForm>({
 		validateOn: "input",
@@ -27,10 +29,18 @@ export const useProfileForm = () => {
 		onSuccess: async () => {
 			const token = authnContext().keycloak?.token;
 			const profile = authnContext().profile;
+			const userProfile = userContext().profile;
 			
-			// Refresh user profile data after successful update
+			// Invalidate user profile queries to trigger refetch
 			if (token && profile?.email) {
-				await userContext().actions.refreshProfile(token, profile.email);
+				await queryClient.invalidateQueries({
+					queryKey: queryKeys.getUserProfile(token, profile.email),
+				});
+			}
+			if (token && userProfile?.uuid) {
+				await queryClient.invalidateQueries({
+					queryKey: queryKeys.getUserPersonalDetails(token, userProfile.uuid),
+				});
 			}
 		},
 	}));

--- a/client/src/feat/profile/services/profile-service.ts
+++ b/client/src/feat/profile/services/profile-service.ts
@@ -1,9 +1,13 @@
 import { assertEnv } from "core/utils/assert-env";
+import type { UserPersonalDetails, UserProfile } from "core/context/user/store";
 import type { ProfileForm } from "feat/profile/types";
 import { default as wretch } from "wretch";
 
 assertEnv(import.meta.env.VITE_API_BASE_URL, "API base url not specified");
 const userApi = wretch(`${import.meta.env.VITE_API_BASE_URL}/user`);
+const personalDetailsApi = wretch(
+	`${import.meta.env.VITE_API_BASE_URL}/personal-details`,
+);
 
 export const profileService = (token?: string) => {
 	const updateProfile = async (
@@ -13,7 +17,25 @@ export const profileService = (token?: string) => {
 		await userApi.auth(`Bearer ${token}`).put(values, `/${userUuid}`).res();
 	};
 
+	const getUserProfile = async (email: string): Promise<UserProfile> => {
+		const searchParams = new URLSearchParams({ email });
+		return userApi
+			.auth(`Bearer ${token}`)
+			.get(`?${searchParams.toString()}`)
+			.json<UserProfile>();
+	};
+
+	const getUserPersonalDetails = async (uuid: string): Promise<UserPersonalDetails | null> => {
+		return personalDetailsApi
+			.auth(`Bearer ${token}`)
+			.get(`/user/${uuid}`)
+			.notFound(() => null)
+			.json<UserPersonalDetails | null>();
+	};
+
 	return {
 		updateProfile,
+		getUserProfile,
+		getUserPersonalDetails,
 	};
 };

--- a/client/src/feat/profile/services/profile-service.ts
+++ b/client/src/feat/profile/services/profile-service.ts
@@ -1,13 +1,9 @@
 import { assertEnv } from "core/utils/assert-env";
-import type { UserPersonalDetails, UserProfile } from "core/context/user/store";
 import type { ProfileForm } from "feat/profile/types";
 import { default as wretch } from "wretch";
 
 assertEnv(import.meta.env.VITE_API_BASE_URL, "API base url not specified");
 const userApi = wretch(`${import.meta.env.VITE_API_BASE_URL}/user`);
-const personalDetailsApi = wretch(
-	`${import.meta.env.VITE_API_BASE_URL}/personal-details`,
-);
 
 export const profileService = (token?: string) => {
 	const updateProfile = async (
@@ -17,25 +13,7 @@ export const profileService = (token?: string) => {
 		await userApi.auth(`Bearer ${token}`).put(values, `/${userUuid}`).res();
 	};
 
-	const getUserProfile = async (email: string): Promise<UserProfile> => {
-		const searchParams = new URLSearchParams({ email });
-		return userApi
-			.auth(`Bearer ${token}`)
-			.get(`?${searchParams.toString()}`)
-			.json<UserProfile>();
-	};
-
-	const getUserPersonalDetails = async (uuid: string): Promise<UserPersonalDetails | null> => {
-		return personalDetailsApi
-			.auth(`Bearer ${token}`)
-			.get(`/user/${uuid}`)
-			.notFound(() => null)
-			.json<UserPersonalDetails | null>();
-	};
-
 	return {
 		updateProfile,
-		getUserProfile,
-		getUserPersonalDetails,
 	};
 };


### PR DESCRIPTION
Fixes #365

https://github.com/user-attachments/assets/f612c707-04eb-4223-9cf3-a5482e5a6163

## Summary
- Add refreshProfile method to user store to refetch user data
- Call refreshProfile after successful profile update to sync UI
- Remove query cache invalidation approach (user context uses Zustand, not tanstack-query)

## Test plan
- [ ] Navigate to profile page
- [ ] Update profile details (firstName, lastName, email)
- [ ] Submit the form
- [ ] Verify that user context shows updated details immediately
- [ ] Check navbar or other components that display user info

🤖 Generated with [Claude Code](https://claude.ai/code)