### PR TITLE
feat: cache eventing store

### DIFF
--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -19,6 +19,7 @@
                  [io.opentelemetry/opentelemetry-api "1.50.0"]
                  [metosin/spec-tools "0.10.7"]
                  [org.clj-commons/pretty "3.4.1"]
+                 [ring-logger "1.1.1"]
                  ;; comment when dev - use checkout
                  ;; lein monolith link imigresen/common
                  [imigresen/common "SNAPSHOT"] ;;

--- a/api/imigresen-api/src/imigresen_api/app/core.clj
+++ b/api/imigresen-api/src/imigresen_api/app/core.clj
@@ -31,18 +31,22 @@
             [reitit.spec :as rs]
             [ring.core.protocols :as ring-protocols]
             [imigresen-common.app.middleware.cors :as imi-cors]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [imigresen-common.state.keycloak.core]
+            [ring.logger :as logger])
   (:import (java.util UUID)
            (java.io Writer)))
 
 (defn init []
   (imi-logging/init-logging)
   (mount/start #'imigresen-common.state.db.core/db
-               #'imigresen-common.state.flipt.core/flipt))
+               #'imigresen-common.state.flipt.core/flipt
+               #'imigresen-common.state.keycloak.core/keycloak))
 
 (defn destroy []
   (mount/stop #'imigresen-common.state.db.core/db
-              #'imigresen-common.state.flipt.core/flipt))
+              #'imigresen-common.state.flipt.core/flipt
+              #'imigresen-common.state.keycloak.core/keycloak))
 
 (defn- response-writer ^Writer [response output-stream]
   (if-let [charset (ring-res/get-charset response)]
@@ -165,4 +169,6 @@
                                     :jsonEditor true}})
                          (reitit-ring/create-default-handler)))))
 
-(def app (create-app (imi-core/handlers)))
+(def app (logger/wrap-with-logger (create-app (imi-core/handlers))
+                                  {:log-fn (fn [{:keys [level throwable message]}]
+                                             (tel/log! {:level level :data {:details message :ex throwable}}))}))

--- a/api/skulpture-eventing/project.clj
+++ b/api/skulpture-eventing/project.clj
@@ -14,7 +14,8 @@
                  [danlentz/clj-uuid "0.2.0"]
                  [clojure.java-time "1.4.3"]
                  [com.taoensso/truss "2.1.0"]
-                 [metosin/spec-tools "0.10.7"]]
+                 [metosin/spec-tools "0.10.7"]
+                 [org.clojure/core.cache "1.1.234"]]
   :profiles {:uberjar {:jvm-opts ["-Dclojure.compiler.direct-linking=true"]}
              :test {:env {:timbre-level "ERROR"
                           :log-level "ERROR"}

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core.clj
@@ -35,9 +35,9 @@
                                          :time-occurred :time-observed :event-data]
                                 :from :event-journal
                                 :where [:and
-                                        [:= :entity-id entity-id]
+                                        [:= :entity-id :?entity-id]
                                         [:= :event-agent (:snapshot agents/system-agents)]
-                                        [:> :revision revision-start]]
+                                        [:> :revision :?revision-start]]
                                 :order-by [[:time-occurred :asc] [:revision :asc]]}]
                               [[:events {:columns [:entity-id :revision :event-agent
                                                    :time-occurred :time-observed :event-data]}]
@@ -45,18 +45,19 @@
                                          :time-occurred :time-observed :event-data]
                                 :from :event-journal
                                 :where [:and
-                                        [:= :entity-id entity-id]
+                                        [:= :entity-id :?entity-id]
                                         [:> :revision [:coalesce
                                                        {:select [[[:max :revision]]]
                                                         :from :snapshots}
-                                                       revision-start]]]
+                                                       :?revision-start]]]
                                 :order-by [[:time-occurred :asc] [:revision :asc]]}]]
                        :union [{:select [:*]
                                 :from :snapshots}
                                {:select [:*]
                                 :from :events
                                 :order-by [[:time-occurred :asc] [:revision :asc]]}]}
-                      (sql/format))
+                      (sql/format {:cache lirs-cache :params {:entity-id entity-id
+                                                              :revision-start revision-start}}))
             result (jdbc/execute! connectable query)
             combined (into [] cat [(:events cached-events) result])]
         (when (not (cache/has? @lirs-cache entity-id))
@@ -77,7 +78,7 @@
                                      :time-occurred :time-observed :event-data]
                             :from :event-journal
                             :where [:and
-                                    [:in :entity-id entity-ids]
+                                    [:in :entity-id :?entity-ids]
                                     [:= :event-agent (:snapshot agents/system-agents)]]
                             :order-by [[:entity-id :asc] [:time-occurred :asc] [:revision :asc]]}]
                           [[:events {:columns [:entity-id :revision :event-agent
@@ -86,18 +87,19 @@
                                      :time-occurred :time-observed :event-data]
                             :from :event-journal
                             :where [:and
-                                    [:in :entity-id entity-ids]
+                                    [:in :entity-id :?entity-ids]
                                     [:> :revision [:coalesce
                                                    {:select [[[:max :revision]]]
                                                     :from :snapshots}
-                                                   0]]]
+                                                   :?revision-start]]]
                             :order-by [[:entity-id :asc] [:time-occurred :asc] [:revision :asc]]}]]
                    :union [{:select [:*]
                             :from :snapshots}
                            {:select [:*]
                             :from :events
                             :order-by [[:entity-id :asc] [:time-occurred :asc] [:revision :asc]]}]}
-                  (sql/format))
+                  (sql/format {:params {:entity-ids entity-ids
+                                        :revision-start 0}}))
         result (jdbc/execute! connectable query)]
     result))
 
@@ -125,10 +127,10 @@
                                          :time-occurred :time-observed :event-data]
                                 :from :event-journal
                                 :where [:and
-                                        [:= :entity-id entity-id]
+                                        [:= :entity-id :?entity-id]
                                         [:= :event-agent (:snapshot agents/system-agents)]
-                                        [:<= :revision revision]
-                                        [:>= :revision revision-start]]
+                                        [:<= :revision :?revision-end]
+                                        [:>= :revision :?revision-start]]
                                 :order-by [[:time-occurred :asc] [:revision :asc]]}]
                               [[:events {:columns [:entity-id :revision :event-agent
                                                    :time-occurred :time-observed :event-data]}]
@@ -136,20 +138,22 @@
                                          :time-occurred :time-observed :event-data]
                                 :from :event-journal
                                 :where [:and
-                                        [:= :entity-id entity-id]
+                                        [:= :entity-id :?entity-id]
                                         [:> :revision [:coalesce
                                                        {:select [[[:max :revision]]]
                                                         :from :snapshots}
                                                        0]]
-                                        [:<= :revision revision]
-                                        [:>= :revision revision-start]]
+                                        [:<= :revision :?revision-end]
+                                        [:>= :revision :?revision-start]]
                                 :order-by [[:time-occurred :asc] [:revision :asc]]}]]
                        :union [{:select [:*]
                                 :from :snapshots}
                                {:select [:*]
                                 :from :events
                                 :order-by [[:time-occurred :asc] [:revision :asc]]}]}
-                      (sql/format))
+                      (sql/format {:cache lirs-cache :params {:entity-id entity-id
+                                                              :revision-start revision-start
+                                                              :revision-end revision}}))
             result (jdbc/execute! connectable query)
             combined (into [] cat [(:events cached-events) result])]
         (swap! lirs-cache cache/miss entity-id {:events combined
@@ -173,14 +177,16 @@
       (let [query (-> {:select [[[:count :entity-id]]]
                        :from :event-journal
                        :where [:= :entity-id entity-id]}
-                      (sql/format))
+                      (sql/format {:cache lirs-cache
+                                   :params {:entity-id entity-id}}))
             result (jdbc/execute-one! connectable query)]
         (:count result)))))
 
 (defn persist!
   "Persist a stream of events"
   [connectable events]
-  (let [query! (-> {:insert-into [:event-journal]
+  ;; TODO: parameterizing values throws
+  (let [query! (-> {:insert-into :event-journal
                     :columns [:event-agent :entity-id :time-occurred :time-observed :event-data :revision]
                     :values (map transformers/->sql-value events)
                     :returning :*}

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core.clj
@@ -51,11 +51,11 @@
                                                         :from :snapshots}
                                                        :?revision-start]]]
                                 :order-by [[:time-occurred :asc] [:revision :asc]]}]]
-                       :union [{:select [:*]
-                                :from :snapshots}
-                               {:select [:*]
-                                :from :events
-                                :order-by [[:time-occurred :asc] [:revision :asc]]}]}
+                       :union-all [{:select [:*]
+                                    :from :snapshots}
+                                   {:select [:*]
+                                    :from :events
+                                    :order-by [[:time-occurred :asc] [:revision :asc]]}]}
                       (sql/format {:cache lirs-cache :params {:entity-id entity-id
                                                               :revision-start revision-start}}))
             result (jdbc/execute! connectable query)
@@ -93,11 +93,11 @@
                                                     :from :snapshots}
                                                    :?revision-start]]]
                             :order-by [[:entity-id :asc] [:time-occurred :asc] [:revision :asc]]}]]
-                   :union [{:select [:*]
-                            :from :snapshots}
-                           {:select [:*]
-                            :from :events
-                            :order-by [[:entity-id :asc] [:time-occurred :asc] [:revision :asc]]}]}
+                   :union-all [{:select [:*]
+                                :from :snapshots}
+                               {:select [:*]
+                                :from :events
+                                :order-by [[:entity-id :asc] [:time-occurred :asc] [:revision :asc]]}]}
                   (sql/format {:params {:entity-ids entity-ids
                                         :revision-start 0}}))
         result (jdbc/execute! connectable query)]
@@ -146,11 +146,11 @@
                                         [:<= :revision :?revision-end]
                                         [:>= :revision :?revision-start]]
                                 :order-by [[:time-occurred :asc] [:revision :asc]]}]]
-                       :union [{:select [:*]
-                                :from :snapshots}
-                               {:select [:*]
-                                :from :events
-                                :order-by [[:time-occurred :asc] [:revision :asc]]}]}
+                       :union-all [{:select [:*]
+                                    :from :snapshots}
+                                   {:select [:*]
+                                    :from :events
+                                    :order-by [[:time-occurred :asc] [:revision :asc]]}]}
                       (sql/format {:cache lirs-cache :params {:entity-id entity-id
                                                               :revision-start revision-start
                                                               :revision-end revision}}))

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core.clj
@@ -2,7 +2,12 @@
   (:require [honey.sql :as sql]
             [next.jdbc :as jdbc]
             [skulpture-eventing.store.agents :as agents]
-            [skulpture-eventing.store.transformers :as transformers]))
+            [skulpture-eventing.store.transformers :as transformers]
+            [clojure.core.cache :as cache]))
+
+(def lirs-cache (atom (cache/lirs-cache-factory {})))
+
+(def ^:dynamic *cache-event-store* true)
 
 (defn load-by-entity-id
   "Load all events for an entity by its id.
@@ -11,35 +16,53 @@
    
    If snapshots are available starts from the snapshot."
   [connectable entity-id]
-  (let [query (-> {:with [[[:snapshots {:columns [:entity-id :revision :event-agent
-                                                  :time-occurred :time-observed :event-data]}]
-                           {:select [:entity-id :revision :event-agent
-                                     :time-occurred :time-observed :event-data]
-                            :from :event-journal
-                            :where [:and
-                                    [:= :entity-id entity-id]
-                                    [:= :event-agent (:snapshot agents/system-agents)]]
-                            :order-by [[:time-occurred :asc] [:revision :asc]]}]
-                          [[:events {:columns [:entity-id :revision :event-agent
-                                               :time-occurred :time-observed :event-data]}]
-                           {:select [:entity-id :revision :event-agent
-                                     :time-occurred :time-observed :event-data]
-                            :from :event-journal
-                            :where [:and
-                                    [:= :entity-id entity-id]
-                                    [:> :revision [:coalesce
-                                                   {:select [[[:max :revision]]]
-                                                    :from :snapshots}
-                                                   0]]]
-                            :order-by [[:time-occurred :asc] [:revision :asc]]}]]
-                   :union [{:select [:*]
-                            :from :snapshots}
-                           {:select [:*]
-                            :from :events
-                            :order-by [[:time-occurred :asc] [:revision :asc]]}]}
-                  (sql/format))
-        result (jdbc/execute! connectable query)]
-    result))
+  (let [cached-events (if (and *cache-event-store*
+                               (cache/has? @lirs-cache entity-id))
+                        (do
+                          (swap! lirs-cache cache/hit entity-id)
+                          (cache/lookup @lirs-cache entity-id))
+                        {:events [] :revision 0 :dirty false})]
+    (if (and (not= (:revision cached-events) 0)
+             (not (:dirty cached-events))
+             (not-empty cached-events))
+      (:events cached-events)
+      (let [revision-start (if (not-empty (:events cached-events))
+                             (:revision (last cached-events))
+                             0)
+            query (-> {:with [[[:snapshots {:columns [:entity-id :revision :event-agent
+                                                      :time-occurred :time-observed :event-data]}]
+                               {:select [:entity-id :revision :event-agent
+                                         :time-occurred :time-observed :event-data]
+                                :from :event-journal
+                                :where [:and
+                                        [:= :entity-id entity-id]
+                                        [:= :event-agent (:snapshot agents/system-agents)]
+                                        [:> :revision revision-start]]
+                                :order-by [[:time-occurred :asc] [:revision :asc]]}]
+                              [[:events {:columns [:entity-id :revision :event-agent
+                                                   :time-occurred :time-observed :event-data]}]
+                               {:select [:entity-id :revision :event-agent
+                                         :time-occurred :time-observed :event-data]
+                                :from :event-journal
+                                :where [:and
+                                        [:= :entity-id entity-id]
+                                        [:> :revision [:coalesce
+                                                       {:select [[[:max :revision]]]
+                                                        :from :snapshots}
+                                                       revision-start]]]
+                                :order-by [[:time-occurred :asc] [:revision :asc]]}]]
+                       :union [{:select [:*]
+                                :from :snapshots}
+                               {:select [:*]
+                                :from :events
+                                :order-by [[:time-occurred :asc] [:revision :asc]]}]}
+                      (sql/format))
+            result (jdbc/execute! connectable query)
+            combined (into [] cat [(:events cached-events) result])]
+        (when (not (cache/has? @lirs-cache entity-id))
+          (swap! lirs-cache cache/miss entity-id {:events combined
+                                                  :revision (or (:revision (last combined)) 0)}))
+        (:events (cache/lookup @lirs-cache entity-id))))))
 
 (defn load-by-entity-ids
   "Load all events for entities by entity ids.
@@ -85,47 +108,74 @@
    
    If snapshots are available starts from the snapshot."
   [connectable entity-id revision]
-  (let [query (-> {:with [[[:snapshots {:columns [:entity-id :revision :event-agent
-                                                  :time-occurred :time-observed :event-data]}]
-                           {:select [:entity-id :revision :event-agent
-                                     :time-occurred :time-observed :event-data]
-                            :from :event-journal
-                            :where [:and
-                                    [:= :entity-id entity-id]
-                                    [:= :event-agent (:snapshot agents/system-agents)]
-                                    [:<= :revision revision]]
-                            :order-by [[:time-occurred :asc] [:revision :asc]]}]
-                          [[:events {:columns [:entity-id :revision :event-agent
-                                               :time-occurred :time-observed :event-data]}]
-                           {:select [:entity-id :revision :event-agent
-                                     :time-occurred :time-observed :event-data]
-                            :from :event-journal
-                            :where [:and
-                                    [:= :entity-id entity-id]
-                                    [:> :revision [:coalesce
-                                                   {:select [[[:max :revision]]]
-                                                    :from :snapshots}
-                                                   0]]
-                                    [:<= :revision revision]]
-                            :order-by [[:time-occurred :asc] [:revision :asc]]}]]
-                   :union [{:select [:*]
-                            :from :snapshots}
-                           {:select [:*]
-                            :from :events
-                            :order-by [[:time-occurred :asc] [:revision :asc]]}]}
-                  (sql/format))
-        result (jdbc/execute! connectable query)]
-    result))
+  (let [cached-events (if (and *cache-event-store*
+                               (cache/has? @lirs-cache entity-id))
+                        (do
+                          (swap! lirs-cache cache/hit entity-id)
+                          (cache/lookup @lirs-cache entity-id))
+                        {:events [] :revision 0 :dirty false})]
+    (if (>= (:revision cached-events) revision)
+      (filter #(<= (:revision %) revision) (:events cached-events))
+      (let [revision-start (if (not-empty (:events cached-events))
+                             (:revision (last cached-events))
+                             0)
+            query (-> {:with [[[:snapshots {:columns [:entity-id :revision :event-agent
+                                                      :time-occurred :time-observed :event-data]}]
+                               {:select [:entity-id :revision :event-agent
+                                         :time-occurred :time-observed :event-data]
+                                :from :event-journal
+                                :where [:and
+                                        [:= :entity-id entity-id]
+                                        [:= :event-agent (:snapshot agents/system-agents)]
+                                        [:<= :revision revision]
+                                        [:>= :revision revision-start]]
+                                :order-by [[:time-occurred :asc] [:revision :asc]]}]
+                              [[:events {:columns [:entity-id :revision :event-agent
+                                                   :time-occurred :time-observed :event-data]}]
+                               {:select [:entity-id :revision :event-agent
+                                         :time-occurred :time-observed :event-data]
+                                :from :event-journal
+                                :where [:and
+                                        [:= :entity-id entity-id]
+                                        [:> :revision [:coalesce
+                                                       {:select [[[:max :revision]]]
+                                                        :from :snapshots}
+                                                       0]]
+                                        [:<= :revision revision]
+                                        [:>= :revision revision-start]]
+                                :order-by [[:time-occurred :asc] [:revision :asc]]}]]
+                       :union [{:select [:*]
+                                :from :snapshots}
+                               {:select [:*]
+                                :from :events
+                                :order-by [[:time-occurred :asc] [:revision :asc]]}]}
+                      (sql/format))
+            result (jdbc/execute! connectable query)
+            combined (into [] cat [(:events cached-events) result])]
+        (swap! lirs-cache cache/miss entity-id {:events combined
+                                                :revision (or (:revision (last combined)) 0)
+                                                :dirty false})
+        (:events (cache/lookup @lirs-cache entity-id))))))
 
 (defn count-by-entity-id
   "Count the number of events for an entity by its id"
   [connectable entity-id]
-  (let [query (-> {:select [[[:count :entity-id]]]
-                   :from :event-journal
-                   :where [:= :entity-id entity-id]}
-                  (sql/format))
-        result (jdbc/execute-one! connectable query)]
-    (:count result)))
+  (let [cached-events (if (and *cache-event-store*
+                               (cache/has? @lirs-cache entity-id))
+                        (do
+                          (swap! lirs-cache cache/hit entity-id)
+                          (cache/lookup @lirs-cache entity-id))
+                        {:events [] :revision 0 :dirty false})]
+    (if (and (not= (:revision cached-events) 0)
+             (not (:dirty cached-events))
+             (not-empty cached-events))
+      (count (:events cached-events))
+      (let [query (-> {:select [[[:count :entity-id]]]
+                       :from :event-journal
+                       :where [:= :entity-id entity-id]}
+                      (sql/format))
+            result (jdbc/execute-one! connectable query)]
+        (:count result)))))
 
 (defn persist!
   "Persist a stream of events"
@@ -135,5 +185,11 @@
                     :values (map transformers/->sql-value events)
                     :returning :*}
                    (sql/format))
-        result (jdbc/execute! connectable query!)]
+        result (jdbc/execute! connectable query!)
+        entity-ids (distinct (map :entity-id events))]
+    ;; we have cached values but the entity has been modified so
+    ;; do a fetch from the db since the last revision we have in cache
+    (doseq [x entity-ids
+            :when (cache/has? @lirs-cache x)]
+      (swap! lirs-cache assoc-in [x :dirty] true))
     result))

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core.clj
@@ -7,7 +7,7 @@
 
 (def lirs-cache (atom (cache/lirs-cache-factory {})))
 
-(def ^:dynamic *cache-event-store* true)
+(def ^:dynamic *event-store-cache* true)
 
 (defn load-by-entity-id
   "Load all events for an entity by its id.
@@ -16,7 +16,7 @@
    
    If snapshots are available starts from the snapshot."
   [connectable entity-id]
-  (let [cached-events (if (and *cache-event-store*
+  (let [cached-events (if (and *event-store-cache*
                                (cache/has? @lirs-cache entity-id))
                         (do
                           (swap! lirs-cache cache/hit entity-id)
@@ -110,7 +110,7 @@
    
    If snapshots are available starts from the snapshot."
   [connectable entity-id revision]
-  (let [cached-events (if (and *cache-event-store*
+  (let [cached-events (if (and *event-store-cache*
                                (cache/has? @lirs-cache entity-id))
                         (do
                           (swap! lirs-cache cache/hit entity-id)
@@ -164,7 +164,7 @@
 (defn count-by-entity-id
   "Count the number of events for an entity by its id"
   [connectable entity-id]
-  (let [cached-events (if (and *cache-event-store*
+  (let [cached-events (if (and *event-store-cache*
                                (cache/has? @lirs-cache entity-id))
                         (do
                           (swap! lirs-cache cache/hit entity-id)


### PR DESCRIPTION
<img width="882" height="337" alt="image" src="https://github.com/user-attachments/assets/42cfc696-d419-49e4-a75a-c1c8bbf6ef77" />

<img width="795" height="144" alt="image" src="https://github.com/user-attachments/assets/be965099-c9db-4529-bfa7-2776d3b1a00b" />

- need to investigate why things are taking so long locally (first request is 1.4s)
   - bit of a stupid mistake
      - not using futures
      - keycloak client maintains a pool, not sure about the details of it but it looks like the first time the client is used it is a little slower, everything after is fine: https://cljdoc.org/d/keycloak-clojure/keycloak-clojure/1.31.5/api/keycloak.deployment#REST_CONNECTION_POOL_SIZE
      - migrated making keycloak a state
      - added request loggers
      - for areas where we get draft automerge urls by user id, there are checks against keycloak as well so first request is a little slow after that its faster

acceptable now, just first few requests after fresh deployment is a little slow:

<img width="1390" height="422" alt="image" src="https://github.com/user-attachments/assets/c0cd4bbb-4ee9-4667-9efd-5b31621382c8" />

related:
- #401 