### PR TITLE
feat: persist and next-revision' to be used without loading the entity in full

### DIFF
--- a/api/skulpture-eventing/src/skulpture_eventing/entity/apply.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/entity/apply.clj
@@ -1,4 +1,7 @@
 (ns skulpture-eventing.entity.apply
+  "This namespace is not meant to be used directly
+     
+   Use `skulpture-eventing.entity.core` instead"
   (:require [taoensso.truss :as truss]))
 
 (declare aggregate

--- a/api/skulpture-eventing/src/skulpture_eventing/entity/core.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/entity/core.clj
@@ -87,8 +87,16 @@
          :events (into [] cat [(:events aggregate) (:uncommitted-events aggregate)])
          :uncommitted-events []}))))
 
+(defn persist!
+  "Persist events for an entity without loading all its events"
+  [connectable events] {:pre [(and (truss/have? #(satisfies? jdbc-protocols/Connectable %) connectable)
+                                   (truss/have? vector? events)
+                                   (truss/have? es/aggregate? aggregate))]}
+  (truss/have (store/persist! connectable events))
+  events)
+
 (defn next-revision
-  "Determine the next revision of the entity from an aggregate or the current state.
+  "Determine the next revision of an entity from an aggregate or the current state.
    
    The latest revision of events for an entity is also the revision of the current state of the entity
    so revisions should only increase as more events are associated with an entity"
@@ -107,6 +115,15 @@
          schema (truss/have ((keyword entity) @schema-registry))]
      (when (truss/have (partial s/valid? schema) (:aggregate aggregate))
        (apply/next-revision (:aggregate aggregate))))))
+
+(defn next-revision'
+  "Determine the next revision of an entity without loading its event stream
+   
+   Does not check whether the state of the entity is valid"
+  [connectable entity-id] {:pre [(and (truss/have? #(satisfies? jdbc-protocols/Connectable %) connectable)
+                                      (truss/have? #(or (string? %) (number? %) (uuid? %)) entity-id)
+                                      (truss/have? es/aggregate? aggregate))]}
+  (store/next-revision connectable (str entity-id)))
 
 (defn snapshot!
   "Creates and persists a snapshot event of the current state of the entity.

--- a/api/skulpture-eventing/src/skulpture_eventing/entity/core.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/entity/core.clj
@@ -90,8 +90,7 @@
 (defn persist!
   "Persist events for an entity without loading all its events"
   [connectable events] {:pre [(and (truss/have? #(satisfies? jdbc-protocols/Connectable %) connectable)
-                                   (truss/have? vector? events)
-                                   (truss/have? es/aggregate? aggregate))]}
+                                   (truss/have? vector? events))]}
   (truss/have (store/persist! connectable events))
   events)
 
@@ -121,8 +120,7 @@
    
    Does not check whether the state of the entity is valid"
   [connectable entity-id] {:pre [(and (truss/have? #(satisfies? jdbc-protocols/Connectable %) connectable)
-                                      (truss/have? #(or (string? %) (number? %) (uuid? %)) entity-id)
-                                      (truss/have? es/aggregate? aggregate))]}
+                                      (truss/have? #(or (string? %) (number? %) (uuid? %)) entity-id))]}
   (store/next-revision connectable (str entity-id)))
 
 (defn snapshot!

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core.clj
@@ -1,4 +1,7 @@
 (ns skulpture-eventing.store.core
+  "This namespace is not meant to be used directly
+   
+   Use `skulpture-eventing.entity.core` instead"
   (:require [honey.sql :as sql]
             [next.jdbc :as jdbc]
             [skulpture-eventing.store.agents :as agents]
@@ -179,11 +182,32 @@
       (count (:events cached-events))
       (let [query (-> {:select [[[:count :1]]]
                        :from :event-journal
-                       :where [:= :entity-id entity-id]}
+                       :where [:= :entity-id :?entity-id]}
                       (sql/format {:cache lirs-cache
                                    :params {:entity-id entity-id}}))
             result (jdbc/execute-one! connectable query)]
         (:count result)))))
+
+(defn next-revision
+  "Get the next revision without loading all events for an entity"
+  [connectable entity-id]
+  (let [cached-events (if (and *event-store-cache*
+                               (cache/has? @lirs-cache entity-id))
+                        (do
+                          (swap! lirs-cache cache/hit entity-id)
+                          (cache/lookup @lirs-cache entity-id))
+                        {:events [] :revision 0 :dirty false})]
+    (if (and (not= (:revision cached-events) 0)
+             (not (:dirty cached-events))
+             (not-empty cached-events))
+      (inc' (:revision (last (:events cached-events))))
+      (let [query (-> {:select [[[:max :revision]]]
+                       :from :event-journal
+                       :where [:= :entity-id :?entity-id]}
+                      (sql/format {:cache lirs-cache
+                                   :params {:entity-id entity-id}}))
+            result (jdbc/execute-one! connectable query)]
+        (inc' (or (:max result) 0))))))
 
 (defn persist!
   "Persist a stream of events"


### PR DESCRIPTION
allows for decoupling components

tests in another pr, there's stuff for caching as well