### PR TITLE
feat: projections

### DIFF
--- a/api/skulpture-eventing/resources/migrations/20250904074536-create-table-event-journal-projections.down.sql
+++ b/api/skulpture-eventing/resources/migrations/20250904074536-create-table-event-journal-projections.down.sql
@@ -1,0 +1,3 @@
+DROP TRIGGER IF EXISTS event_journal_projections_modtimestamp;
+--;;
+DROP TABLE IF EXISTS event_journal_projections;

--- a/api/skulpture-eventing/resources/migrations/20250904074536-create-table-event-journal-projections.up.sql
+++ b/api/skulpture-eventing/resources/migrations/20250904074536-create-table-event-journal-projections.up.sql
@@ -1,13 +1,18 @@
 CREATE TABLE IF NOT EXISTS event_journal_projections (
-    id INTEGER GENERATED ALWAYS AS IDENTITY,
+    id BIGINT GENERATED ALWAYS AS IDENTITY,
     entity_id TEXT NOT NULL,
     projection_type TEXT NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     revision BIGINT NOT NULL,
-    snapshot_data JSONB NOT NULL,
+    projection JSONB NOT NULL,
     last_updated_by TEXT NOT NULL,
     UNIQUE(entity_id, projection_type),
-    CONSTRAINT pk_event_journal_projections PRIMARY KEY(id, entity_id, updated_at, last_updated_by)
+    CONSTRAINT pk_event_journal_projections PRIMARY KEY(
+        id,
+        projection_type,
+        entity_id,
+        updated_at,
+        last_updated_by)
 )
 --;;
 CREATE OR REPLACE TRIGGER event_journal_projections_modtimestamp

--- a/api/skulpture-eventing/resources/migrations/20250904074536-create-table-event-journal-projections.up.sql
+++ b/api/skulpture-eventing/resources/migrations/20250904074536-create-table-event-journal-projections.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS event_journal_projections (
+    id INTEGER GENERATED ALWAYS AS IDENTITY,
+    entity_id TEXT NOT NULL,
+    projection_type TEXT NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    revision BIGINT NOT NULL,
+    snapshot_data JSONB NOT NULL,
+    last_updated_by TEXT NOT NULL,
+    UNIQUE(entity_id, projection_type),
+    CONSTRAINT pk_event_journal_projections PRIMARY KEY(id, entity_id, updated_at, last_updated_by)
+)
+--;;
+CREATE OR REPLACE TRIGGER event_journal_projections_modtimestamp
+    BEFORE UPDATE ON event_journal_projections
+    FOR EACH ROW
+    WHEN (OLD IS DISTINCT FROM NEW)
+        EXECUTE PROCEDURE moddatetime (updated_at)

--- a/api/skulpture-eventing/src/skulpture_eventing/entity/core.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/entity/core.clj
@@ -2,12 +2,15 @@
 
 (def schema-registry
   "Used to ensure that the reduced state of the entity is valid.
-   
+
    An entity can only be loaded if a schema is defined for it"
   (atom {}))
 
 (declare aggregate)
 (load "core/aggregate")
+
+(declare project!)
+(load "core/project")
 
 (declare commit!)
 (load "core/commit")

--- a/api/skulpture-eventing/src/skulpture_eventing/entity/core/aggregate.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/entity/core/aggregate.clj
@@ -11,7 +11,7 @@
 (defn aggregate
   "Gets the events associated with the entity id and determines the current state of the event,
    applying any additional events if specified. Additional events are not committed, to do so invoke `commit!`.
-   
+
    An aggregate is composed of: the current state of the entity, events which have been committed and uncommitted events
    which have been applied to determine the current state. Expects a vector when events to apply are specified as
    order is important"
@@ -33,7 +33,8 @@
      (let [current-state (apply/aggregate transformer (into [] cat [committed-events uncommitted-events]))
            schema (truss/have ((keyword entity)  @schema-registry))]
        (when (truss/have (partial s/valid? schema) current-state)
-         {:aggregate current-state :events committed-events :uncommitted-events uncommitted-events}))))
+         {:projection-type entity :aggregate current-state
+          :events committed-events :uncommitted-events uncommitted-events}))))
   ([connectable entity entity-id transformer]
    {:pre [(and (truss/have? #(satisfies? jdbc-protocols/Connectable %) connectable)
                (truss/have? keyword? entity)
@@ -44,7 +45,8 @@
        (let [current-state (apply/aggregate transformer committed-events)
              schema (truss/have ((keyword entity) @schema-registry))]
          (when (truss/have (partial s/valid? schema) current-state :data {:type :validation-error :explain (s/explain schema current-state)})
-           {:aggregate current-state :events committed-events :uncommitted-events []})))))
+           {:projection-type entity :aggregate current-state :events
+            committed-events :uncommitted-events []})))))
   ([connectable entity entity-id-or-aggregate transformer events]
    {:pre [(and (truss/have? #(satisfies? jdbc-protocols/Connectable %) connectable)
                (truss/have? keyword? entity)
@@ -57,7 +59,8 @@
            current-state (apply/aggregate transformer (into [] cat [committed-events uncommitted-events events]))
            schema (truss/have ((keyword entity)  @schema-registry))]
        (when (truss/have (partial s/valid? schema) current-state)
-         {:aggregate current-state :events committed-events :uncommitted-events events}))
+         {:projection-type entity :aggregate current-state :events
+          committed-events :uncommitted-events events}))
      (let [committed-events (store/load-by-entity-id connectable (str entity-id-or-aggregate))]
        (if (and (some? committed-events) (not-empty committed-events))
          (let [current-state (apply/aggregate transformer (into [] cat [committed-events events]))
@@ -67,4 +70,5 @@
          (let [current-state (apply/aggregate transformer events)
                schema (truss/have ((keyword entity)  @schema-registry))]
            (when (truss/have (partial s/valid? schema) current-state)
-             {:aggregate current-state :events [] :uncommitted-events events})))))))
+             {:projection-type entity :aggregate current-state
+              :events [] :uncommitted-events events})))))))

--- a/api/skulpture-eventing/src/skulpture_eventing/entity/core/commit.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/entity/core/commit.clj
@@ -9,12 +9,20 @@
 
 (defn commit!
   "Commit uncommitted events in an aggregate"
-  [connectable entity aggregate] {:pre [(and (truss/have? #(satisfies? jdbc-protocols/Connectable %) connectable)
-                                             (truss/have? keyword? entity)
-                                             (truss/have? es/aggregate? aggregate))]}
+  [connectable entity aggregate]
+  ;; TODO: need to update existing usages
+  {:pre [(and (and (truss/have? #(satisfies? jdbc-protocols/Connectable %) connectable)
+                   (truss/have? #((complement satisfies?) jdbc-protocols/Wrapped) connectable)
+                   (truss/have? #((complement satisfies?) jdbc-protocols/Transactable) connectable))
+              (truss/have? keyword? entity)
+              (truss/have? es/aggregate? aggregate))]}
   (let [schema ((keyword entity) @schema-registry)]
     (when (truss/have (partial s/valid? schema) (:aggregate aggregate))
-      (let [_result (truss/have (store/persist! connectable (:uncommitted-events aggregate)))]
-        {:aggregate (:aggregate aggregate)
-         :events (into [] cat [(:events aggregate) (:uncommitted-events aggregate)])
-         :uncommitted-events []}))))
+      (jdbc/with-transaction [tx connectable]
+        (let [result (pvalues
+                      (truss/have (project! tx aggregate))
+                      (truss/have (store/persist! connectable (:uncommitted-events aggregate))))
+              completed (every? some? result)]
+          {:aggregate (:aggregate aggregate)
+           :events (into [] cat [(:events aggregate) (:uncommitted-events aggregate)])
+           :uncommitted-events []})))))

--- a/api/skulpture-eventing/src/skulpture_eventing/entity/core/project.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/entity/core/project.clj
@@ -18,7 +18,7 @@
    (let [projection-type (:entity aggregate)
          entity-id (:entity-id aggregate)
          revision (get-in aggregate [:aggregate :revision])
-         snapshot-data (-> (get-in aggregate [:aggregate])
-                           (dissoc :revision))
+         projection (-> (get-in aggregate [:aggregate])
+                        (dissoc :revision))
          agent (:event-agent (last (into [] cat [(:committed-events aggregate) (:uncommitted-events aggregate)])))]
-     (store/project! connectable agent projection-type entity-id snapshot-data revision))))
+     (store/project! connectable agent projection-type entity-id projection revision))))

--- a/api/skulpture-eventing/src/skulpture_eventing/entity/core/project.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/entity/core/project.clj
@@ -1,0 +1,24 @@
+(in-ns 'skulpture-eventing.entity.core)
+(require '[skulpture-eventing.store.core :as store]
+         '[java-time.api :as jt]
+         '[taoensso.truss :as truss]
+         '[clojure.spec.alpha :as s]
+         '[skulpture-eventing.store.agents :as agents]
+         '[next.jdbc.protocols :as jdbc-protocols]
+         '[skulpture-eventing.entity.spec :as es])
+
+(defn project!
+  "Creates and persists a projecion of the current state of the entity from an aggregate"
+  ([connectable aggregate]
+   {:pre [(and (or (truss/have? #(satisfies? jdbc-protocols/Transactable %) connectable)
+                   (and (truss/have? #(satisfies? jdbc-protocols/Connectable %) connectable)
+                        (truss/have? #((complement satisfies?) jdbc-protocols/Wrapped connectable))))
+               (truss/have? es/aggregate? aggregate)
+               (truss/have? #(some? (get-in aggregate [:aggregate :revision]))))]}
+   (let [projection-type (:entity aggregate)
+         entity-id (:entity-id aggregate)
+         revision (get-in aggregate [:aggregate :revision])
+         snapshot-data (-> (get-in aggregate [:aggregate])
+                           (dissoc :revision))
+         agent (:event-agent (last (into [] cat [(:committed-events aggregate) (:uncommitted-events aggregate)])))]
+     (store/project! connectable agent projection-type entity-id snapshot-data revision))))

--- a/api/skulpture-eventing/src/skulpture_eventing/entity/core/snapshot.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/entity/core/snapshot.clj
@@ -12,7 +12,7 @@
 
 (defn snapshot!
   "Creates and persists a snapshot event of the current state of the entity.
-   
+
    Snapshot events are valuable when there are many events for an entity. If a snapshot exists then it is the
    starting point when events are loaded"
   [connectable entity entity-id transformer] {:pre [(and (truss/have? #(satisfies? jdbc-protocols/Connectable %) connectable)

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core.clj
@@ -1,6 +1,6 @@
 (ns skulpture-eventing.store.core
   "This namespace is not meant to be used directly
-   
+
    Use `skulpture-eventing.entity.core` instead"
   (:require [clojure.core.cache :as cache]))
 
@@ -25,3 +25,6 @@
 
 (declare persist!)
 (load "core/persist")
+
+(declare project!)
+(load "core/project")

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core/load-by-entity-id-and-revision.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core/load-by-entity-id-and-revision.clj
@@ -6,11 +6,12 @@
 (declare *event-store-cache*)
 (declare lirs-cache)
 
+;; TODO: update for loading projects from `event_journal_projections`
 (defn load-by-entity-id-and-revision
   "Load all events for an entity by its id and revision.
-   
+
    Events are ordered by the time occurred and their revision.
-   
+
    If snapshots are available starts from the snapshot."
   [connectable entity-id revision]
   (let [cached-events (if (and *event-store-cache*

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core/load-by-entity-id-and-revision.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core/load-by-entity-id-and-revision.clj
@@ -6,7 +6,6 @@
 (declare *event-store-cache*)
 (declare lirs-cache)
 
-;; TODO: update for loading projects from `event_journal_projections`
 (defn load-by-entity-id-and-revision
   "Load all events for an entity by its id and revision.
 

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core/load-by-entity-id.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core/load-by-entity-id.clj
@@ -6,7 +6,6 @@
 (declare ^:dynamic *event-store-cache*)
 (declare lirs-cache)
 
-;; TODO: update for loading projects from `event_journal_projections`
 (defn load-by-entity-id
   "Load all events for an entity by its id.
 

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core/load-by-entity-id.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core/load-by-entity-id.clj
@@ -6,11 +6,12 @@
 (declare ^:dynamic *event-store-cache*)
 (declare lirs-cache)
 
+;; TODO: update for loading projects from `event_journal_projections`
 (defn load-by-entity-id
   "Load all events for an entity by its id.
-   
+
    Events are ordered by the time the occurred and their revision.
-   
+
    If snapshots are available starts from the snapshot."
   [connectable entity-id]
   (let [cached-events (if (and *event-store-cache*

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core/load-by-entity-ids.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core/load-by-entity-ids.clj
@@ -3,11 +3,12 @@
          '[next.jdbc :as jdbc]
          '[skulpture-eventing.store.agents :as agents])
 
+;; TODO: update for loading projects from `event_journal_projections`
 (defn load-by-entity-ids
   "Load all events for entities by entity ids.
-   
+
    Events are ordered by the time occurred and their revision.
-   
+
    If snapshots are available starts from the snapshot."
   [connectable entity-ids]
   (let [query (-> {:with [[[:snapshots {:columns [:entity-id :revision :event-agent

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core/load-by-entity-ids.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core/load-by-entity-ids.clj
@@ -3,7 +3,6 @@
          '[next.jdbc :as jdbc]
          '[skulpture-eventing.store.agents :as agents])
 
-;; TODO: update for loading projects from `event_journal_projections`
 (defn load-by-entity-ids
   "Load all events for entities by entity ids.
 

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core/load-projection-by-entity-id.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core/load-projection-by-entity-id.clj
@@ -1,0 +1,15 @@
+(in-ns 'skulpture-eventing.store.core)
+(require '[honey.sql :as sql]
+         '[next.jdbc :as jdbc]
+         '[skulpture-eventing.store.transformers :as transformers])
+
+(defn load-projection-by-entity-id
+  "Load the current projection of an entity"
+  [connectable projection-type entity-id additional-filters]
+  (let [query {:select :projection
+               :from :event-journal-projections
+               :where (into [:and] cat [[[:= :projection-type projection-type]]
+                                        [[:entity-id entity-id]]
+                                        [additional-filters]])}
+        result (jdbc/execute-one! connectable query)]
+    (transformers/projection<-sql-value result)))

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core/load-projection-by-entity-id.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core/load-projection-by-entity-id.clj
@@ -6,7 +6,7 @@
 (defn load-projection-by-entity-id
   "Load the current projection of an entity"
   [connectable projection-type entity-id additional-filters]
-  (let [query {:select :projection
+  (let [query {:select [:entity-id :projection]
                :from :event-journal-projections
                :where (into [:and] cat [[[:= :projection-type projection-type]]
                                         [[:entity-id entity-id]]

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core/load-projection-by-entity-ids.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core/load-projection-by-entity-ids.clj
@@ -1,0 +1,23 @@
+(in-ns 'skulpture-eventing.store.core)
+(require '[honey.sql :as sql]
+         '[next.jdbc :as jdbc]
+         '[skulpture-eventing.store.transformers :as transformers])
+
+(defn load-projection-by-entity-ids
+  "Load the current projection of entities"
+  [connectable entities]
+  (let [filters (map
+                 (fn [[key value]]
+                   (into [:and] cat [[[:= :projection-type (first %)]]
+                                     ;; TODO: factor out entity id check
+                                     [[:= :entity-id (if (or (string? %) (number? %) (uuid? %))
+                                                       (str (second %))
+                                                       (str (:entity-id (second %))))]]
+                                     (when (not (or (string? %) (number? %) (uuid? %)))
+                                       [(:filters (second %))])]))
+                 entities)
+        query {:select :projection
+               :from :event-journal-projections
+               :where [:or filters]}
+        result (jdbc/execute! connectable query)]
+    (map transformers/projection<-sql-value result)))

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core/load-projection-by-entity-ids.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core/load-projection-by-entity-ids.clj
@@ -16,8 +16,9 @@
                                      (when (not (or (string? %) (number? %) (uuid? %)))
                                        [(:filters (second %))])]))
                  entities)
-        query {:select :projection
+        query {:select [:entity-id :projection]
                :from :event-journal-projections
                :where [:or filters]}
         result (jdbc/execute! connectable query)]
-    (map transformers/projection<-sql-value result)))
+    (update-vals (group-by :entity-id (map transformers/projection<-sql-value result))
+                 first)))

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core/persist.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core/persist.clj
@@ -9,7 +9,7 @@
   "Persist a stream of events"
   [connectable events]
   (let [query! (-> {:insert-into :event-journal
-                    :values      (map transformers/->sql-value events)
+                    :values      (map transformers/event->sql-value events)
                     :returning   :*}
                    (sql/format))
         result (jdbc/execute! connectable query!)

--- a/api/skulpture-eventing/src/skulpture_eventing/store/core/project.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/core/project.clj
@@ -1,0 +1,14 @@
+(in-ns 'skulpture-eventing.store.core)
+(require '[honey.sql :as sql]
+         '[next.jdbc :as jdbc]
+         '[skulpture-eventing.store.transformers :as transformers])
+
+(defn project!
+  "Persist a projection"
+  [connectable agent projection-type entity-id snapshot revision]
+  (let [query! (-> {:insert-into :event-journal
+                    :values      (map transformers/snapshot->sql-value agent projection-type entity-id snapshot revision)
+                    :returning   :*}
+                   (sql/format))
+        result (jdbc/execute! connectable query!)]
+    result))

--- a/api/skulpture-eventing/src/skulpture_eventing/store/transformers.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/transformers.clj
@@ -18,4 +18,4 @@
                               :projection [:lift projection]}))
 
 (defn projection<-sql-value (fn [v]
-                              (:event-journal/projection v)))
+                              (merge {:entity-id (:event-journal/entity-id v)} (:event-journal/projection v))))

--- a/api/skulpture-eventing/src/skulpture_eventing/store/transformers.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/transformers.clj
@@ -10,9 +10,12 @@
                           :event-data [:lift (:event-data event)]
                           :revision (:revision event)}))
 
-(def snapshot->sql-value (fn [agent projection-type entity-id snapshot revision]
-                           {:projection-type (str projection-type)
-                            :last-updated-by (str agent)
-                            :entity-id (str entity-id)
-                            :revision revision
-                            :snapshot-data [:lift snapshot]}))
+(def projection->sql-value (fn [agent projection-type entity-id projection revision]
+                             {:projection-type (str projection-type)
+                              :last-updated-by (str agent)
+                              :entity-id (str entity-id)
+                              :revision revision
+                              :projection [:lift projection]}))
+
+(defn projection<-sql-value (fn [v]
+                              (:event-journal/projection v)))

--- a/api/skulpture-eventing/src/skulpture_eventing/store/transformers.clj
+++ b/api/skulpture-eventing/src/skulpture_eventing/store/transformers.clj
@@ -2,10 +2,17 @@
   (:require [clj-uuid :as uuid]
             [java-time.api :as jt]))
 
-(def ->sql-value  (fn [event]
-                    {:event-agent (:event-agent event)
-                     :entity-id (str (or (:entity-id event) (uuid/v7)))
-                     :time-occurred (or (:time-occurred event) (jt/instant))
-                     :time-observed (:time-observed event)
-                     :event-data [:lift (:event-data event)]
-                     :revision (:revision event)}))
+(def event->sql-value  (fn [event]
+                         {:event-agent (:event-agent event)
+                          :entity-id (str (or (:entity-id event) (uuid/v7)))
+                          :time-occurred (or (:time-occurred event) (jt/instant))
+                          :time-observed (:time-observed event)
+                          :event-data [:lift (:event-data event)]
+                          :revision (:revision event)}))
+
+(def snapshot->sql-value (fn [agent projection-type entity-id snapshot revision]
+                           {:projection-type (str projection-type)
+                            :last-updated-by (str agent)
+                            :entity-id (str entity-id)
+                            :revision revision
+                            :snapshot-data [:lift snapshot]}))


### PR DESCRIPTION
automatically store projections of an entity when committing the result of an aggregate

TODO:
- need to update store load to load projections + events. both snapshots and projections serve the same purpose but snapshots are treated as events. there is only one projection which is current and we still want to get the events associated with an entity

- tests