### PR TITLE
chore: fix dev namespace reloading

### DIFF
--- a/api/.vscode/settings.json
+++ b/api/.vscode/settings.json
@@ -25,7 +25,7 @@
 			}
 		},
 		{
-			"name": "Imigresen API",
+			"name": "imigresen-api",
 			"projectType": "Leiningen",
 			"autoSelectForJackIn": true,
 			"autoSelectForConnect": true,

--- a/api/imigresen-api/Dockerfile
+++ b/api/imigresen-api/Dockerfile
@@ -8,7 +8,7 @@ COPY . ./imigresen-api
 
 RUN cd skulpture-eventing && lein install
 RUN cd imigresen-common && lein install
-RUN cd imigresen-api && lein build
+RUN cd imigresen-api && lein build.prod
 
 FROM eclipse-temurin:24-jre-alpine
 
@@ -18,5 +18,5 @@ COPY --from=build /build/imigresen-api/target/uberjar/api-0.1.0-SNAPSHOT-standal
 ENTRYPOINT [ "java", "-jar", "/app/api-standalone.jar" ]
 
 # note: if migrations are not included then try this
-# see: 
+# see:
 # ENTRYPOINT ["java", "-showversion", "-cp", "/app/common-standalone.jar:/app/api-standalone.jar", "imigresen_api.app.core.main"]

--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -25,6 +25,8 @@
                  ;; for dev and resolve dynamically so that we don't have to include it in prod
                  [io.github.tonsky/clj-reload "0.9.8"]
                  [watchtower "0.1.1"]
+                 [nrepl/nrepl "1.4.0"]
+                 [cider/cider-nrepl "0.57.0"]
                  ;; comment when dev - use checkout
                  ;; lein monolith link imigresen/common
                  [imigresen/common "SNAPSHOT"] ;;

--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -26,10 +26,11 @@
                  ;; lein monolith link imigresen/common
                  [imigresen/common "SNAPSHOT"]]
   :resource-paths ["resources"]
-  :main ^:skip-aot imigresen-api.app.server
+
   :target-path "target/%s"
   :profiles {:dev {:env {:java-env "development"
                          :taoensso-telemere-rt-min-level ":debug"}
+                   :main ^:skip-aot imigresen-api.app.server
                    :dependencies [[ring/ring-devel "1.14.1"]
                                   [io.github.tonsky/clj-reload "0.9.8"]
                                   [watchtower "0.1.1"]]}
@@ -38,6 +39,7 @@
                              :log-level "ERROR"}
                        :uberjar-exclusions [#".*_test\.(clj|java)"]
                        :aot :all
+                       :main imigresen-api.app.server
                        :dependencies [[ring/ring-devel "1.14.1" :scope "provided"]
                                       [ring/ring-mock "0.6.1" :scope "provided"]
                                       [org.clojure/data.json "2.5.1" :scope "provided"]]
@@ -46,6 +48,7 @@
              :test {:env {:timbre-level "ERROR"
                           :log-level "ERROR"
                           :java-env "test"}
+                    :main ^:skip-aot imigresen-api.app.server
                     :dependencies [[org.clojure/data.json "2.5.1"]
                                    [ring/ring-mock "0.6.1"]]}}
   :test-paths ["src"]
@@ -56,8 +59,6 @@
             [dev.weavejester/lein-cljfmt "LATEST"]
             [lein-monolith "LATEST"]
             [lein-checkout-deps "1.0.0"]]
-  ;; uncomment to seed database
-  ;; :migratus {:migration-dir "seeds"}
   :aliases {"dev" ["do" "deps," "run"]
             "build.prod" ["uberjar"]
             "build.watch" ["auto" "build.prod"]

--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -55,8 +55,8 @@
   ;; uncomment to seed database
   ;; :migratus {:migration-dir "seeds"}
   :aliases {"dev" ["do" "deps," "run"]
-            "build" ["uberjar"]
-            "build.watch" ["auto" "uberjar"]
+            "build.prod" ["uberjar"]
+            "build.watch" ["auto" "build.prod"]
             "test" ["do", "deps," "test"]
             "test.watch" ["do" "deps," "auto" "test"]
             "repl" ["repl"]}

--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -20,6 +20,9 @@
                  [metosin/spec-tools "0.10.7"]
                  [org.clj-commons/pretty "3.4.1"]
                  [ring-logger "1.1.1"]
+                 ;; TODO: this is not a dep thats required for the prod build. import only
+                 ;; for dev
+                 [io.github.tonsky/clj-reload "0.9.8"]
                  ;; comment when dev - use checkout
                  ;; lein monolith link imigresen/common
                  [imigresen/common "SNAPSHOT"] ;;

--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -23,74 +23,26 @@
                  [ring/ring-jetty-adapter "1.14.2"]
                  [nrepl/nrepl "1.4.0"]
                  [cider/cider-nrepl "0.57.0"]
-                 ;; comment when dev - use checkout
                  ;; lein monolith link imigresen/common
-                 [imigresen/common "SNAPSHOT"] ;;
-                 ]
+                 [imigresen/common "SNAPSHOT"]]
   :resource-paths ["resources"]
   :main ^:skip-aot imigresen-api.app.server
   :target-path "target/%s"
   :profiles {:dev {:env {:java-env "development"
                          :taoensso-telemere-rt-min-level ":debug"}
                    :dependencies [[ring/ring-devel "1.14.1"]
-                                  ;; imigresen-common deps for checkout
-                                  [keycloak-clojure/keycloak-clojure "1.31.5"]
-                                  [com.github.seancorfield/honeysql "2.7.1310"]
-                                  [com.github.seancorfield/next.jdbc "1.3.1048"]
-                                  [org.postgresql/postgresql "42.7.7"]
-                                  [com.zaxxer/HikariCP "6.3.0"]
-                                  [environ "1.2.0"]
-                                  [metosin/reitit "0.9.1"]
-                                  [metosin/ring-swagger-ui "5.20.0"]
-                                  [metosin/muuntaja "0.6.11"]
-                                  [mount "0.1.23"]
-                                  [buddy/buddy-auth "3.0.323"]
-                                  [org.clojure/core.match "1.1.0"]
-                                  [migratus "1.6.4"]
-                                  [org.slf4j/slf4j-log4j12 "2.0.17"]
-                                  [com.taoensso/telemere "1.0.1"]
-                                  [http-kit "2.8.0"]
-                                  [danlentz/clj-uuid "0.2.0"]
-                                  [clojure.java-time "1.4.3"]
-                                  [org.threeten/threeten-extra "1.8.0"]
-                                  [camel-snake-kebab "0.4.3"]
-                                  [jumblerg/ring-cors "3.0.0"]
-                                  [com.taoensso/truss "2.1.0"]
-                                  [io.opentelemetry/opentelemetry-api "1.50.0"]
-                                  [org.clojure/tools.logging "1.3.0"]
-                                  [io.sentry/sentry-clj "7.22.227"]
-                                  [metosin/spec-tools "0.10.7"]
-                                  [metosin/jsonista "0.3.13"]
-                                  [io.randomseed/phone-number "8.13.6-3"]
                                   [io.github.tonsky/clj-reload "0.9.8"]
-                                  [watchtower "0.1.1"]
-                                  ;; AWS dependencies
-                                  [amazonica "0.3.168" :exclusions [com.amazonaws/aws-java-sdk
-                                                                    com.amazonaws/amazon-kinesis-client
-                                                                    com.amazonaws/dynamodb-lock-client]]
-                                  [com.amazonaws/aws-java-sdk-s3 "1.12.788"]
-                                  [com.amazonaws/aws-java-sdk-core "1.12.788"]
-                                  ;; imigresen-common test deps for checkout
-                                  ;; hmr fails otherwise
-                                  [clj-test-containers/clj-test-containers "0.7.4"]
-                                  [org.testcontainers/postgresql "1.21.2"]
-                                  ;; not required for dev, its only used in tests but
-                                  ;; hmr throws without it
-                                  [ring/ring-mock "0.6.1"]]}
+                                  [watchtower "0.1.1"]]}
              :uberjar {:env {:java-env "production"
                              :timbre-level "ERROR"
                              :log-level "ERROR"}
                        :aot [imigresen-api.app.server]
                        ;; https://cljdoc.org/d/com.taoensso/telemere/1.0.1/api/taoensso.telemere.tools-logging#tools-logging-%3Etelemere!
-                       :jvm-opts ["-Dclojure.compiler.direct-linking=true -Dclojure.tools.logging.to-telemere=true"]
-                       ;; checkout for dev
-                       :dependencies [[imigresen/common "SNAPSHOT"]]}
+                       :jvm-opts ["-Dclojure.compiler.direct-linking=true -Dclojure.tools.logging.to-telemere=true"]}
              :test {:env {:timbre-level "ERROR"
                           :log-level "ERROR"
                           :java-env "test"}
-                    :dependencies [;; checkout for dev
-                                   [imigresen/common "SNAPSHOT"]
-                                   [org.clojure/data.json "2.5.1"]
+                    :dependencies [[org.clojure/data.json "2.5.1"]
                                    [ring/ring-mock "0.6.1"]]}}
   :test-paths ["src"]
   :plugins [[lein-environ "LATEST"]
@@ -98,14 +50,15 @@
             [migratus-lein "0.7.3"]
             [lein-ancient "LATEST"]
             [dev.weavejester/lein-cljfmt "LATEST"]
-            [lein-monolith "LATEST"]]
+            [lein-monolith "LATEST"]
+            [lein-checkout-deps "1.0.0"]]
   ;; uncomment to seed database
   ;; :migratus {:migration-dir "seeds"}
-  :aliases {"dev" ["run"]
+  :aliases {"dev" ["do" "deps," "run"]
             "build" ["uberjar"]
             "build.watch" ["auto" "uberjar"]
-            "test" ["test"]
-            "test.watch" ["auto" "test"]
+            "test" ["do", "deps," "test"]
+            "test.watch" ["do" "deps," "auto" "test"]
             "repl" ["repl"]}
   :test-selectors {:default (complement :integration)
                    :unit (fn

--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -36,7 +36,11 @@
              :uberjar {:env {:java-env "production"
                              :timbre-level "ERROR"
                              :log-level "ERROR"}
-                       :aot [imigresen-api.app.server]
+                       :uberjar-exclusions [#".*_test\.(clj|java)"]
+                       :aot :all
+                       :dependencies [[ring/ring-devel "1.14.1" :scope "provided"]
+                                      [ring/ring-mock "0.6.1" :scope "provided"]
+                                      [org.clojure/data.json "2.5.1" :scope "provided"]]
                        ;; https://cljdoc.org/d/com.taoensso/telemere/1.0.1/api/taoensso.telemere.tools-logging#tools-logging-%3Etelemere!
                        :jvm-opts ["-Dclojure.compiler.direct-linking=true -Dclojure.tools.logging.to-telemere=true"]}
              :test {:env {:timbre-level "ERROR"

--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -59,6 +59,8 @@
                                   [metosin/spec-tools "0.10.7"]
                                   [metosin/jsonista "0.3.13"]
                                   [io.randomseed/phone-number "8.13.6-3"]
+                                  [io.github.tonsky/clj-reload "0.9.8"]
+                                  [watchtower "0.1.1"]
                                   ;; AWS dependencies
                                   [amazonica "0.3.168" :exclusions [com.amazonaws/aws-java-sdk
                                                                     com.amazonaws/amazon-kinesis-client

--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -32,7 +32,7 @@
                  [imigresen/common "SNAPSHOT"] ;;
                  ]
   :resource-paths ["resources"]
-  :main ^:skip-aot imigresen-api.app.core
+  :main ^:skip-aot imigresen-api.app.server
   :target-path "target/%s"
   :profiles {:dev {:env {:java-env "development"
                          :taoensso-telemere-rt-min-level ":debug"}
@@ -84,7 +84,7 @@
              :uberjar {:env {:java-env "production"
                              :timbre-level "ERROR"
                              :log-level "ERROR"}
-                       :aot [imigresen-api.app.core]
+                       :aot [imigresen-api.app.server]
                        ;; https://cljdoc.org/d/com.taoensso/telemere/1.0.1/api/taoensso.telemere.tools-logging#tools-logging-%3Etelemere!
                        :jvm-opts ["-Dclojure.compiler.direct-linking=true -Dclojure.tools.logging.to-telemere=true"]
                        ;; checkout for dev

--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -21,10 +21,6 @@
                  [org.clj-commons/pretty "3.4.1"]
                  [ring-logger "1.1.1"]
                  [ring/ring-jetty-adapter "1.14.2"]
-                 ;; TODO: this is not a dep thats required for the prod build. import only
-                 ;; for dev and resolve dynamically so that we don't have to include it in prod
-                 [io.github.tonsky/clj-reload "0.9.8"]
-                 [watchtower "0.1.1"]
                  [nrepl/nrepl "1.4.0"]
                  [cider/cider-nrepl "0.57.0"]
                  ;; comment when dev - use checkout

--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -22,8 +22,9 @@
                  [ring-logger "1.1.1"]
                  [ring/ring-jetty-adapter "1.14.2"]
                  ;; TODO: this is not a dep thats required for the prod build. import only
-                 ;; for dev
+                 ;; for dev and resolve dynamically so that we don't have to include it in prod
                  [io.github.tonsky/clj-reload "0.9.8"]
+                 [watchtower "0.1.1"]
                  ;; comment when dev - use checkout
                  ;; lein monolith link imigresen/common
                  [imigresen/common "SNAPSHOT"] ;;

--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -20,6 +20,7 @@
                  [metosin/spec-tools "0.10.7"]
                  [org.clj-commons/pretty "3.4.1"]
                  [ring-logger "1.1.1"]
+                 [ring/ring-jetty-adapter "1.14.2"]
                  ;; TODO: this is not a dep thats required for the prod build. import only
                  ;; for dev
                  [io.github.tonsky/clj-reload "0.9.8"]
@@ -94,21 +95,16 @@
                                    [ring/ring-mock "0.6.1"]]}}
   :test-paths ["src"]
   :plugins [[lein-environ "LATEST"]
-            [lein-ring "LATEST" :auto-refresh? true]
             [lein-auto "LATEST"]
             [migratus-lein "0.7.3"]
             [lein-ancient "LATEST"]
             [dev.weavejester/lein-cljfmt "LATEST"]
             [lein-monolith "LATEST"]]
-  :ring {:init imigresen-api.app.core/init
-         :destroy imigresen-api.app.core/destroy
-         :handler imigresen-api.app.core/app
-         :nrepl {:start true :port 3001}}
   ;; uncomment to seed database
   ;; :migratus {:migration-dir "seeds"}
-  :aliases {"dev" ["ring" "server-headless"]
-            "build" ["ring" "uberjar"]
-            "build.watch" ["auto" "ring" "uberjar"]
+  :aliases {"dev" ["run"]
+            "build" ["uberjar"]
+            "build.watch" ["auto" "uberjar"]
             "test" ["test"]
             "test.watch" ["auto" "test"]
             "repl" ["repl"]}

--- a/api/imigresen-api/src/imigresen_api/app/core.clj
+++ b/api/imigresen-api/src/imigresen_api/app/core.clj
@@ -189,25 +189,33 @@
                                   {:log-fn (fn [{:keys [level throwable message]}]
                                              (tel/log! {:level level :data {:details message :ex throwable}}))}))
 
-(def server (let [port (imi-env/env :port (s/or :number number?
-                                                :string imi-env/str->num) 3000)
-                  server (adapter/run-jetty app {:port port
-                                                 :join? false})]
-              (println "Listening on port" port)
-              server))
+(defn create-server [atom]
+  (reset! atom (let [port (imi-env/env :port (s/or :number number?
+                                                   :string imi-env/str->num) 3000)
+                     server (adapter/run-jetty app {:port port
+                                                    :join? false})]
+                 (println "Listening on port" port)
+                 server)))
 
-(def nrepl-server (let [port (imi-env/env :nrepl-port (s/or :number number?
-                                                            :string imi-env/str->num) 4321)
-                        server (nrepl/start-server :port port
-                                                   :handler cider/cider-nrepl-handler)]
-                    (println "nREPL server listening on port" port)
-                    (spit ".nrepl-port" port)
-                    server))
+(defn create-nrepl-server [atom]
+  (reset! atom (let [port (imi-env/env :nrepl-port (s/or :number number?
+                                                         :string imi-env/str->num) 4321)
+                     server (nrepl/start-server :port port
+                                                :handler cider/cider-nrepl-handler)]
+                 (println "nREPL server listening on port" port)
+                 (spit ".nrepl-port" port)
+                 server)))
+
+(def server (atom nil))
+
+(def nrepl-server (atom nil))
 
 #_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
 (defn before-ns-unload []
-  (.stop server)
-  (nrepl/stop-server nrepl-server))
+  (when @server
+    (.stop @server))
+  (when @nrepl-server
+    (nrepl/stop-server nrepl-server)))
 
 ;; from: https://github.com/MichaelBlume/ring-server/blob/master/src/ring/server/standalone.clj#L41C1-L45C16
 (defmacro ^{:private true} in-thread
@@ -226,5 +234,7 @@
 
 (defn -main [& _args]
   (init)
-  (add-destroy-hook server (. (Runtime/getRuntime)
-                              (addShutdownHook (Thread. destroy)))))
+  (create-server server)
+  (create-nrepl-server nrepl-server)
+  (add-destroy-hook @server (. (Runtime/getRuntime)
+                               (addShutdownHook (Thread. destroy)))))

--- a/api/imigresen-api/src/imigresen_api/app/core.clj
+++ b/api/imigresen-api/src/imigresen_api/app/core.clj
@@ -10,7 +10,6 @@
             [reitit.ring.coercion]
             [reitit.ring.middleware.exception :as reitit-exception]
             [reitit.ring.middleware.multipart]
-            [mount.core :as mount]
             [imigresen-api.api.core :as imi-core]
             [imigresen-common.state.db.core]
             [imigresen-common.state.flipt.core]
@@ -22,7 +21,6 @@
             [muuntaja.core :as m]
             [camel-snake-kebab.core :as csk]
             [imigresen-common.app.swagger :as imi-swagger]
-            [imigresen-common.app.logging :as imi-logging]
             [clj-commons.format.exceptions :as pexceptions]
             [taoensso.telemere :as tel]
             [sentry-clj.core :as sentry]
@@ -31,41 +29,9 @@
             [imigresen-common.app.middleware.cors :as imi-cors]
             [clojure.java.io :as io]
             [imigresen-common.state.keycloak.core]
-            [ring.logger :as logger]
-            [clj-reload.core :as reload]
-            [watchtower.core :as watchtower]
-            [ring.adapter.jetty :as adapter]
-            [nrepl.server :as nrepl]
-            [cider.nrepl :as cider]
-            [clojure.spec.alpha :as s])
+            [ring.logger :as logger])
   (:import (java.util UUID)
            (java.io Writer)))
-
-(defn init! [& {:keys [unload-hook reload-hook watch-dirs] :as _opts
-                :or {unload-hook 'before-ns-unload
-                     reload-hook 'after-ns-reload
-                     watch-dirs ["src" "checkouts" "resources"]}}]
-  (imi-logging/init-logging)
-  (mount/start #'imigresen-common.state.db.core/db
-               #'imigresen-common.state.flipt.core/flipt
-               #'imigresen-common.state.keycloak.core/keycloak)
-  (when (imi-env/development? (imi-env/current-env))
-    (reload/init {:output :verbose
-                  :unload-hook unload-hook
-                  :reload-hook reload-hook})
-    (let [reload-count (atom 0)]
-      (watchtower/watcher watch-dirs
-                          (watchtower/rate 20)
-                          (watchtower/on-change (fn [files]
-                                                  (when (> @reload-count 0)
-                                                    (println "files changed: " (map #(.getPath %) files)))
-                                                  (reload/reload)
-                                                  (swap! reload-count inc)))))))
-
-(defn destroy []
-  (mount/stop #'imigresen-common.state.db.core/db
-              #'imigresen-common.state.flipt.core/flipt
-              #'imigresen-common.state.keycloak.core/keycloak))
 
 (defn- response-writer ^Writer [response output-stream]
   (if-let [charset (ring-res/get-charset response)]
@@ -188,59 +154,3 @@
 (def app (logger/wrap-with-logger (create-app (imi-core/handlers))
                                   {:log-fn (fn [{:keys [level throwable message]}]
                                              (tel/log! {:level level :data {:details message :ex throwable}}))}))
-
-(defn create-server [atom]
-  (reset! atom (let [port (imi-env/env :port (s/or :number number?
-                                                   :string imi-env/str->num) 3000)
-                     server (adapter/run-jetty app {:port port
-                                                    :join? false})]
-                 (println "Listening on port" port)
-                 server)))
-
-(defn create-nrepl-server [atom]
-  (reset! atom (let [port (imi-env/env :nrepl-port (s/or :number number?
-                                                         :string imi-env/str->num) 4321)
-                     server (nrepl/start-server :port port
-                                                :handler cider/cider-nrepl-handler)]
-                 (println "nREPL server listening on port" port)
-                 (spit ".nrepl-port" port)
-                 server)))
-
-(def server (atom nil))
-
-(def nrepl-server (atom nil))
-
-;; from: https://github.com/MichaelBlume/ring-server/blob/master/src/ring/server/standalone.clj#L41C1-L45C16
-(defmacro ^{:private true} in-thread
-  "Execute the body in a new thread and return the Thread object."
-  [& body]
-  `(doto (Thread. (fn [] ~@body))
-     (.start)))
-
-;; from: https://github.com/MichaelBlume/ring-server/blob/master/src/ring/server/standalone.clj#L47
-(defn- add-destroy-hook
-  "Add a destroy hook to be executed when the server ends."
-  [server destroy]
-  (in-thread
-   (try (.join server)
-        (finally (when destroy (destroy))))))
-
-(defn start! [server nrepl-server]
-  (create-server server)
-  (create-nrepl-server nrepl-server)
-  (add-destroy-hook @server (. (Runtime/getRuntime)
-                               (addShutdownHook (Thread. destroy)))))
-
-#_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
-(defn before-ns-unload []
-  (when @server
-    (.stop @server))
-  (when @nrepl-server
-    (nrepl/stop-server @nrepl-server)))
-
-#_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
-(defn after-ns-reload [] (start! server nrepl-server))
-
-(defn -main [& _args]
-  (start! server nrepl-server)
-  (init!))

--- a/api/imigresen-api/src/imigresen_api/app/core.clj
+++ b/api/imigresen-api/src/imigresen_api/app/core.clj
@@ -188,7 +188,7 @@
                                   {:log-fn (fn [{:keys [level throwable message]}]
                                              (tel/log! {:level level :data {:details message :ex throwable}}))}))
 
-(def server (let [server (adapter/run-jetty app {:port 3000 :join? false :daemon? true})]
+(def server (let [server (adapter/run-jetty app {:port 3000 :join? false})]
               (println "Listening on port 3000")
               server))
 

--- a/api/imigresen-api/src/imigresen_api/app/core.clj
+++ b/api/imigresen-api/src/imigresen_api/app/core.clj
@@ -33,7 +33,8 @@
             [imigresen-common.state.keycloak.core]
             [ring.logger :as logger]
             [clj-reload.core :as reload]
-            [watchtower.core :as watchtower])
+            [watchtower.core :as watchtower]
+            [ring.adapter.jetty :as adapter])
   (:import (java.util UUID)
            (java.io Writer)))
 
@@ -179,3 +180,50 @@
 (def app (logger/wrap-with-logger (create-app (imi-core/handlers))
                                   {:log-fn (fn [{:keys [level throwable message]}]
                                              (tel/log! {:level level :data {:details message :ex throwable}}))}))
+
+;; -----------
+;; THIS WORKS
+(def server (adapter/run-jetty app {:port 3000 :join? false}))
+
+(defn -main [& _args]
+  (println "HERE!!")
+  (init)
+  ;; TODO: we need to join the server thread and destroy
+  ;;(destroy)
+  )
+
+#_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
+(defn before-ns-unload
+  "Ensure proper shutdown before reloading namespaces
+
+   Only used in development"
+  []
+  (-> server
+      (.stop)))
+
+;; ------------
+;; BUT WANT TO MAKE IT WORK LIKE THIS
+;; when we create a server we add a global var and then the `before-ns-unload` hook
+;; grabs that and shutsdown the server
+;; it is reloading right now but after its reloaded something about the server is wrong
+;; because fails to fetch openapi.json
+
+;; (defn create-server [{:keys [init destroy] :as opts}]
+;;   (when init (init))
+;;   ;; TODO: destroy only after server has shutdown
+;;   ;; we need to know when `.stop` on server is called
+;;   (let [server (adapter/run-jetty app {:port 3000 :join? false})]
+;;     (intern *ns* 'server server)))
+
+;; (defn -main [& _args]
+;;   (create-server {:init init
+;;                   :destroy destroy}))
+
+;; #_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
+;; (defn before-ns-unload
+;;   "Ensure proper shutdown before reloading namespaces
+
+;;    Only used in development"
+;;   []
+;;   (-> @(resolve 'server)
+;;       (.stop)))

--- a/api/imigresen-api/src/imigresen_api/app/core.clj
+++ b/api/imigresen-api/src/imigresen_api/app/core.clj
@@ -10,8 +10,6 @@
             [reitit.ring.coercion]
             [reitit.ring.middleware.exception :as reitit-exception]
             [reitit.ring.middleware.multipart]
-            [ring.middleware.reload :as reload]
-            [ring.middleware.lint :as lint]
             [mount.core :as mount]
             [imigresen-api.api.core :as imi-core]
             [imigresen-common.state.db.core]
@@ -33,7 +31,9 @@
             [imigresen-common.app.middleware.cors :as imi-cors]
             [clojure.java.io :as io]
             [imigresen-common.state.keycloak.core]
-            [ring.logger :as logger])
+            [ring.logger :as logger]
+            [clj-reload.core :as reload]
+            [watchtower.core :as watchtower])
   (:import (java.util UUID)
            (java.io Writer)))
 
@@ -41,7 +41,17 @@
   (imi-logging/init-logging)
   (mount/start #'imigresen-common.state.db.core/db
                #'imigresen-common.state.flipt.core/flipt
-               #'imigresen-common.state.keycloak.core/keycloak))
+               #'imigresen-common.state.keycloak.core/keycloak)
+  (when (imi-env/development? (imi-env/current-env))
+    (reload/init {:output :verbose})
+    (let [reload-count (atom 0)]
+      (watchtower/watcher ["src" "checkouts"]
+                          (watchtower/rate 20)
+                          (watchtower/on-change (fn [files]
+                                                  (when (> @reload-count 0)
+                                                    (println "files changed: " (map #(.getPath %) files)))
+                                                  (reload/reload)
+                                                  (swap! reload-count inc)))))))
 
 (defn destroy []
   (mount/stop #'imigresen-common.state.db.core/db
@@ -144,10 +154,7 @@
                            reitit.ring.coercion/coerce-response-middleware
                            ;; openapi feature
                            openapi/openapi-feature]
-        dev-middleware [;; reload namespaces
-                        reload/wrap-reload
-                        ;; lint
-                        lint/wrap-lint]]
+        dev-middleware []]
     (reitit-ring/ring-handler
      (reitit-ring/router
       (conj handlers (openapi) (ping))
@@ -156,7 +163,7 @@
        :data {:coercion reitit-coercion/coercion
               :muuntaja m/instance
               :middleware (if (imi-env/development? (imi-env/current-env))
-                            (conj global-middleware dev-middleware)
+                            (into [] cat [global-middleware dev-middleware])
                             global-middleware)}})
      (reitit-ring/routes (reitit-ring/redirect-trailing-slash-handler)
                          (reitit-swagger/create-swagger-ui-handler

--- a/api/imigresen-api/src/imigresen_api/app/core.clj
+++ b/api/imigresen-api/src/imigresen_api/app/core.clj
@@ -41,10 +41,10 @@
   (:import (java.util UUID)
            (java.io Writer)))
 
-(defn init [& {:keys [unload-hook reload-hook watch-dirs] :as _opts
-               :or {unload-hook 'before-ns-unload
-                    reload-hook 'after-ns-reload
-                    watch-dirs ["src" "checkouts" "resources"]}}]
+(defn init! [& {:keys [unload-hook reload-hook watch-dirs] :as _opts
+                :or {unload-hook 'before-ns-unload
+                     reload-hook 'after-ns-reload
+                     watch-dirs ["src" "checkouts" "resources"]}}]
   (imi-logging/init-logging)
   (mount/start #'imigresen-common.state.db.core/db
                #'imigresen-common.state.flipt.core/flipt
@@ -210,13 +210,6 @@
 
 (def nrepl-server (atom nil))
 
-#_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
-(defn before-ns-unload []
-  (when @server
-    (.stop @server))
-  (when @nrepl-server
-    (nrepl/stop-server nrepl-server)))
-
 ;; from: https://github.com/MichaelBlume/ring-server/blob/master/src/ring/server/standalone.clj#L41C1-L45C16
 (defmacro ^{:private true} in-thread
   "Execute the body in a new thread and return the Thread object."
@@ -232,9 +225,22 @@
    (try (.join server)
         (finally (when destroy (destroy))))))
 
-(defn -main [& _args]
-  (init)
+(defn start! [server nrepl-server]
   (create-server server)
   (create-nrepl-server nrepl-server)
   (add-destroy-hook @server (. (Runtime/getRuntime)
                                (addShutdownHook (Thread. destroy)))))
+
+#_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
+(defn before-ns-unload []
+  (when @server
+    (.stop @server))
+  (when @nrepl-server
+    (nrepl/stop-server @nrepl-server)))
+
+#_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
+(defn after-ns-reload [] (start! server nrepl-server))
+
+(defn -main [& _args]
+  (start! server nrepl-server)
+  (init!))

--- a/api/imigresen-api/src/imigresen_api/app/core.clj
+++ b/api/imigresen-api/src/imigresen_api/app/core.clj
@@ -34,19 +34,26 @@
             [ring.logger :as logger]
             [clj-reload.core :as reload]
             [watchtower.core :as watchtower]
-            [ring.adapter.jetty :as adapter])
+            [ring.adapter.jetty :as adapter]
+            [nrepl.server :as nrepl]
+            [cider.nrepl :as cider])
   (:import (java.util UUID)
            (java.io Writer)))
 
-(defn init []
+(defn init [& {:keys [unload-hook reload-hook watch-dirs] :as _opts
+               :or {unload-hook 'before-ns-unload
+                    reload-hook 'after-ns-reload
+                    watch-dirs ["src" "checkouts" "resources"]}}]
   (imi-logging/init-logging)
   (mount/start #'imigresen-common.state.db.core/db
                #'imigresen-common.state.flipt.core/flipt
                #'imigresen-common.state.keycloak.core/keycloak)
   (when (imi-env/development? (imi-env/current-env))
-    (reload/init {:output :verbose})
+    (reload/init {:output :verbose
+                  :unload-hook unload-hook
+                  :reload-hook reload-hook})
     (let [reload-count (atom 0)]
-      (watchtower/watcher ["src" "checkouts"]
+      (watchtower/watcher watch-dirs
                           (watchtower/rate 20)
                           (watchtower/on-change (fn [files]
                                                   (when (> @reload-count 0)
@@ -181,49 +188,36 @@
                                   {:log-fn (fn [{:keys [level throwable message]}]
                                              (tel/log! {:level level :data {:details message :ex throwable}}))}))
 
-;; -----------
-;; THIS WORKS
-(def server (adapter/run-jetty app {:port 3000 :join? false}))
+(def server (let [server (adapter/run-jetty app {:port 3000 :join? false :daemon? true})]
+              (println "Listening on port 3000")
+              server))
 
-(defn -main [& _args]
-  (println "HERE!!")
-  (init)
-  ;; TODO: we need to join the server thread and destroy
-  ;;(destroy)
-  )
+(def nrepl-server (let [server (nrepl/start-server :port 4321 :handler cider/cider-nrepl-handler)]
+                    (println "nREPL server listening on 4321")
+                    (spit ".nrepl-port" "4321")
+                    server))
 
 #_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
-(defn before-ns-unload
-  "Ensure proper shutdown before reloading namespaces
+(defn before-ns-unload []
+  (.stop server)
+  (nrepl/stop-server nrepl-server))
 
-   Only used in development"
-  []
-  (-> server
-      (.stop)))
+;; from: https://github.com/MichaelBlume/ring-server/blob/master/src/ring/server/standalone.clj#L41C1-L45C16
+(defmacro ^{:private true} in-thread
+  "Execute the body in a new thread and return the Thread object."
+  [& body]
+  `(doto (Thread. (fn [] ~@body))
+     (.start)))
 
-;; ------------
-;; BUT WANT TO MAKE IT WORK LIKE THIS
-;; when we create a server we add a global var and then the `before-ns-unload` hook
-;; grabs that and shutsdown the server
-;; it is reloading right now but after its reloaded something about the server is wrong
-;; because fails to fetch openapi.json
+;; from: https://github.com/MichaelBlume/ring-server/blob/master/src/ring/server/standalone.clj#L47
+(defn- add-destroy-hook
+  "Add a destroy hook to be executed when the server ends."
+  [server destroy]
+  (in-thread
+   (try (.join server)
+        (finally (when destroy (destroy))))))
 
-;; (defn create-server [{:keys [init destroy] :as opts}]
-;;   (when init (init))
-;;   ;; TODO: destroy only after server has shutdown
-;;   ;; we need to know when `.stop` on server is called
-;;   (let [server (adapter/run-jetty app {:port 3000 :join? false})]
-;;     (intern *ns* 'server server)))
-
-;; (defn -main [& _args]
-;;   (create-server {:init init
-;;                   :destroy destroy}))
-
-;; #_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
-;; (defn before-ns-unload
-;;   "Ensure proper shutdown before reloading namespaces
-
-;;    Only used in development"
-;;   []
-;;   (-> @(resolve 'server)
-;;       (.stop)))
+(defn -main [& _args]
+  (init)
+  (add-destroy-hook server (. (Runtime/getRuntime)
+                              (addShutdownHook (Thread. destroy)))))

--- a/api/imigresen-api/src/imigresen_api/app/core.clj
+++ b/api/imigresen-api/src/imigresen_api/app/core.clj
@@ -36,7 +36,8 @@
             [watchtower.core :as watchtower]
             [ring.adapter.jetty :as adapter]
             [nrepl.server :as nrepl]
-            [cider.nrepl :as cider])
+            [cider.nrepl :as cider]
+            [clojure.spec.alpha :as s])
   (:import (java.util UUID)
            (java.io Writer)))
 
@@ -188,13 +189,19 @@
                                   {:log-fn (fn [{:keys [level throwable message]}]
                                              (tel/log! {:level level :data {:details message :ex throwable}}))}))
 
-(def server (let [server (adapter/run-jetty app {:port 3000 :join? false})]
-              (println "Listening on port 3000")
+(def server (let [port (imi-env/env :port (s/or :number number?
+                                                :string imi-env/str->num) 3000)
+                  server (adapter/run-jetty app {:port port
+                                                 :join? false})]
+              (println "Listening on port" port)
               server))
 
-(def nrepl-server (let [server (nrepl/start-server :port 4321 :handler cider/cider-nrepl-handler)]
-                    (println "nREPL server listening on 4321")
-                    (spit ".nrepl-port" "4321")
+(def nrepl-server (let [port (imi-env/env :nrepl-port (s/or :number number?
+                                                            :string imi-env/str->num) 4321)
+                        server (nrepl/start-server :port port
+                                                   :handler cider/cider-nrepl-handler)]
+                    (println "nREPL server listening on port" port)
+                    (spit ".nrepl-port" port)
                     server))
 
 #_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}

--- a/api/imigresen-api/src/imigresen_api/app/server.clj
+++ b/api/imigresen-api/src/imigresen_api/app/server.clj
@@ -25,13 +25,14 @@
                              :unload-hook unload-hook
                              :reload-hook reload-hook})
     (let [reload-count (atom 0)]
-      ((resolve 'watchtower/watcher) watch-dirs
-                                     ((resolve 'watchtower/rate) 20)
-                                     ((resolve 'watchtower/on-change) (fn [files]
-                                                                        (when (> @reload-count 0)
-                                                                          (println "files changed: " (map #(.getPath %) files)))
-                                                                        ((resolve 'reload/reload))
-                                                                        (swap! reload-count inc)))))))
+      (-> ((resolve 'watchtower/watcher*) watch-dirs)
+          ((resolve 'watchtower/rate) 20)
+          ((resolve 'watchtower/on-change) (fn [files]
+                                             (when (> @reload-count 0)
+                                               (println "files changed: " (map #(.getPath %) files)))
+                                             ((resolve 'reload/reload))
+                                             (swap! reload-count inc)))
+          ((resolve 'watchtower/watch))))))
 
 (defn destroy []
   #_{:clj-kondo/ignore [:unresolved-namespace]}

--- a/api/imigresen-api/src/imigresen_api/app/server.clj
+++ b/api/imigresen-api/src/imigresen_api/app/server.clj
@@ -1,8 +1,6 @@
 (ns imigresen-api.app.server
   (:require [imigresen-api.app.core :as core]
             [imigresen-common.app.logging :as imi-logging]
-            [clj-reload.core :as reload]
-            [watchtower.core :as watchtower]
             [ring.adapter.jetty :as adapter]
             [nrepl.server :as nrepl]
             [cider.nrepl :as cider]
@@ -21,17 +19,19 @@
                #'imigresen-common.state.flipt.core/flipt
                #'imigresen-common.state.keycloak.core/keycloak)
   (when (imi-env/development? (imi-env/current-env))
-    (reload/init {:output :verbose
-                  :unload-hook unload-hook
-                  :reload-hook reload-hook})
+    (require '[watchtower.core :as watchtower]
+             '[clj-reload.core :as reload])
+    ((resolve 'reload/init) {:output :verbose
+                             :unload-hook unload-hook
+                             :reload-hook reload-hook})
     (let [reload-count (atom 0)]
-      (watchtower/watcher watch-dirs
-                          (watchtower/rate 20)
-                          (watchtower/on-change (fn [files]
-                                                  (when (> @reload-count 0)
-                                                    (println "files changed: " (map #(.getPath %) files)))
-                                                  (reload/reload)
-                                                  (swap! reload-count inc)))))))
+      ((resolve 'watchtower/watcher) watch-dirs
+                                     ((resolve 'watchtower/rate) 20)
+                                     ((resolve 'watchtower/on-change) (fn [files]
+                                                                        (when (> @reload-count 0)
+                                                                          (println "files changed: " (map #(.getPath %) files)))
+                                                                        ((resolve 'reload/reload))
+                                                                        (swap! reload-count inc)))))))
 
 (defn destroy []
   #_{:clj-kondo/ignore [:unresolved-namespace]}

--- a/api/imigresen-api/src/imigresen_api/app/server.clj
+++ b/api/imigresen-api/src/imigresen_api/app/server.clj
@@ -1,0 +1,96 @@
+(ns imigresen-api.app.server
+  (:require [imigresen-api.app.core :as core]
+            [imigresen-common.app.logging :as imi-logging]
+            [clj-reload.core :as reload]
+            [watchtower.core :as watchtower]
+            [ring.adapter.jetty :as adapter]
+            [nrepl.server :as nrepl]
+            [cider.nrepl :as cider]
+            [clojure.spec.alpha :as s]
+            [imigresen-common.app.env :as imi-env]
+            [mount.core :as mount]))
+
+(defn init! [& {:keys [unload-hook reload-hook watch-dirs] :as _opts
+                :or {unload-hook 'before-ns-unload
+                     reload-hook 'after-ns-reload
+                     watch-dirs ["src" "checkouts" "resources"]}}]
+  (imi-logging/init-logging)
+  #_{:clj-kondo/ignore [:unresolved-namespace]}
+  (mount/start #'imigresen-common.state.db.core/db
+               #'imigresen-common.state.flipt.core/flipt
+               #'imigresen-common.state.keycloak.core/keycloak)
+  (when (imi-env/development? (imi-env/current-env))
+    (reload/init {:output :verbose
+                  :unload-hook unload-hook
+                  :reload-hook reload-hook})
+    (let [reload-count (atom 0)]
+      (watchtower/watcher watch-dirs
+                          (watchtower/rate 20)
+                          (watchtower/on-change (fn [files]
+                                                  (when (> @reload-count 0)
+                                                    (println "files changed: " (map #(.getPath %) files)))
+                                                  (reload/reload)
+                                                  (swap! reload-count inc)))))))
+
+(defn destroy []
+  #_{:clj-kondo/ignore [:unresolved-namespace]}
+  (mount/stop #'imigresen-common.state.db.core/db
+              #'imigresen-common.state.flipt.core/flipt
+              #'imigresen-common.state.keycloak.core/keycloak))
+
+
+(defn create-server [atom]
+  (reset! atom (let [port (imi-env/env :port (s/or :number number?
+                                                   :string imi-env/str->num) 3000)
+                     server (adapter/run-jetty core/app {:port port
+                                                         :join? false})]
+                 (println "Listening on port" port)
+                 server)))
+
+(defn create-nrepl-server [atom]
+  (reset! atom (let [port (imi-env/env :nrepl-port (s/or :number number?
+                                                         :string imi-env/str->num) 4321)
+                     server (nrepl/start-server :port port
+                                                :handler cider/cider-nrepl-handler)]
+                 (println "nREPL server listening on port" port)
+                 (spit ".nrepl-port" port)
+                 server)))
+
+(def server (atom nil))
+
+(def nrepl-server (atom nil))
+
+;; from: https://github.com/MichaelBlume/ring-server/blob/master/src/ring/server/standalone.clj#L41C1-L45C16
+(defmacro ^{:private true} in-thread
+  "Execute the body in a new thread and return the Thread object."
+  [& body]
+  `(doto (Thread. (fn [] ~@body))
+     (.start)))
+
+;; from: https://github.com/MichaelBlume/ring-server/blob/master/src/ring/server/standalone.clj#L47
+(defn- add-destroy-hook
+  "Add a destroy hook to be executed when the server ends."
+  [server destroy]
+  (in-thread
+   (try (.join server)
+        (finally (when destroy (destroy))))))
+
+(defn start! [server nrepl-server]
+  (create-server server)
+  (create-nrepl-server nrepl-server)
+  (add-destroy-hook @server (. (Runtime/getRuntime)
+                               (addShutdownHook (Thread. destroy)))))
+
+#_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
+(defn before-ns-unload []
+  (when @server
+    (.stop @server))
+  (when @nrepl-server
+    (nrepl/stop-server @nrepl-server)))
+
+#_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
+(defn after-ns-reload [] (start! server nrepl-server))
+
+(defn -main [& _args]
+  (start! server nrepl-server)
+  (init!))

--- a/api/imigresen-api/src/imigresen_api/app/server.clj
+++ b/api/imigresen-api/src/imigresen_api/app/server.clj
@@ -8,7 +8,8 @@
             [cider.nrepl :as cider]
             [clojure.spec.alpha :as s]
             [imigresen-common.app.env :as imi-env]
-            [mount.core :as mount]))
+            [mount.core :as mount]
+            [clojure.java.io :as io]))
 
 (defn init! [& {:keys [unload-hook reload-hook watch-dirs] :as _opts
                 :or {unload-hook 'before-ns-unload
@@ -37,7 +38,6 @@
   (mount/stop #'imigresen-common.state.db.core/db
               #'imigresen-common.state.flipt.core/flipt
               #'imigresen-common.state.keycloak.core/keycloak))
-
 
 (defn create-server! [atom]
   (reset! atom (let [port (imi-env/env :port (s/or :number number?
@@ -78,8 +78,12 @@
 (defn start! [server nrepl-server]
   (create-server! server)
   (create-nrepl-server! nrepl-server)
-  (add-destroy-hook @server (. (Runtime/getRuntime)
-                               (addShutdownHook (Thread. destroy)))))
+  (let [shutdown-hook (fn []
+                        (doseq [hook [destroy
+                                      (fn [] (io/delete-file ".nrepl-port" true))]]
+                          (hook)))]
+    (add-destroy-hook @server (. (Runtime/getRuntime)
+                                 (addShutdownHook (Thread. shutdown-hook))))))
 
 #_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
 (defn before-ns-unload []

--- a/api/imigresen-api/src/imigresen_api/app/server.clj
+++ b/api/imigresen-api/src/imigresen_api/app/server.clj
@@ -39,7 +39,7 @@
               #'imigresen-common.state.keycloak.core/keycloak))
 
 
-(defn create-server [atom]
+(defn create-server! [atom]
   (reset! atom (let [port (imi-env/env :port (s/or :number number?
                                                    :string imi-env/str->num) 3000)
                      server (adapter/run-jetty core/app {:port port
@@ -47,7 +47,7 @@
                  (println "Listening on port" port)
                  server)))
 
-(defn create-nrepl-server [atom]
+(defn create-nrepl-server! [atom]
   (reset! atom (let [port (imi-env/env :nrepl-port (s/or :number number?
                                                          :string imi-env/str->num) 4321)
                      server (nrepl/start-server :port port
@@ -76,8 +76,8 @@
         (finally (when destroy (destroy))))))
 
 (defn start! [server nrepl-server]
-  (create-server server)
-  (create-nrepl-server nrepl-server)
+  (create-server! server)
+  (create-nrepl-server! nrepl-server)
   (add-destroy-hook @server (. (Runtime/getRuntime)
                                (addShutdownHook (Thread. destroy)))))
 

--- a/api/imigresen-api/src/imigresen_api/app/server.clj
+++ b/api/imigresen-api/src/imigresen_api/app/server.clj
@@ -7,7 +7,8 @@
             [clojure.spec.alpha :as s]
             [imigresen-common.app.env :as imi-env]
             [mount.core :as mount]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io])
+  (:gen-class))
 
 (defn init! [& {:keys [unload-hook reload-hook watch-dirs] :as _opts
                 :or {unload-hook 'before-ns-unload

--- a/api/imigresen-api/src/imigresen_api/app/server.clj
+++ b/api/imigresen-api/src/imigresen_api/app/server.clj
@@ -10,32 +10,39 @@
             [clojure.java.io :as io])
   (:gen-class))
 
-(defn init! [& {:keys [unload-hook reload-hook watch-dirs] :as _opts
-                :or {unload-hook 'before-ns-unload
-                     reload-hook 'after-ns-reload
-                     watch-dirs ["src" "checkouts" "resources"]}}]
+(def server (atom nil))
+
+(def nrepl-server (atom nil))
+
+(defn watch! [& {:keys [unload-hook reload-hook watch-dirs] :as _opts
+                 :or {unload-hook 'before-ns-unload
+                      reload-hook 'after-ns-reload
+                      watch-dirs ["src" "checkouts" "resources"]}}]
+  (require '[watchtower.core :as watchtower]
+           '[clj-reload.core :as reload])
+  ((resolve 'reload/init) {:output :verbose
+                           :unload-hook unload-hook
+                           :reload-hook reload-hook})
+  (let [reload-count (atom 0)]
+    (-> ((resolve 'watchtower/watcher*) watch-dirs)
+        ((resolve 'watchtower/rate) 20)
+        ((resolve 'watchtower/on-change) (fn [files]
+                                           (when (> @reload-count 0)
+                                             (println "files changed: " (map #(.getPath %) files)))
+                                           ((resolve 'reload/reload))
+                                           (swap! reload-count inc)))
+        ((resolve 'watchtower/watch)))))
+
+(defn init! [& _args]
   (imi-logging/init-logging)
   #_{:clj-kondo/ignore [:unresolved-namespace]}
   (mount/start #'imigresen-common.state.db.core/db
                #'imigresen-common.state.flipt.core/flipt
                #'imigresen-common.state.keycloak.core/keycloak)
   (when (imi-env/development? (imi-env/current-env))
-    (require '[watchtower.core :as watchtower]
-             '[clj-reload.core :as reload])
-    ((resolve 'reload/init) {:output :verbose
-                             :unload-hook unload-hook
-                             :reload-hook reload-hook})
-    (let [reload-count (atom 0)]
-      (-> ((resolve 'watchtower/watcher*) watch-dirs)
-          ((resolve 'watchtower/rate) 20)
-          ((resolve 'watchtower/on-change) (fn [files]
-                                             (when (> @reload-count 0)
-                                               (println "files changed: " (map #(.getPath %) files)))
-                                             ((resolve 'reload/reload))
-                                             (swap! reload-count inc)))
-          ((resolve 'watchtower/watch))))))
+    (watch!)))
 
-(defn destroy []
+(defn destroy! []
   #_{:clj-kondo/ignore [:unresolved-namespace]}
   (mount/stop #'imigresen-common.state.db.core/db
               #'imigresen-common.state.flipt.core/flipt
@@ -58,19 +65,15 @@
                  (spit ".nrepl-port" port)
                  server)))
 
-(def server (atom nil))
-
-(def nrepl-server (atom nil))
-
 ;; from: https://github.com/MichaelBlume/ring-server/blob/master/src/ring/server/standalone.clj#L41C1-L45C16
-(defmacro ^{:private true} in-thread
+(defmacro in-thread
   "Execute the body in a new thread and return the Thread object."
   [& body]
   `(doto (Thread. (fn [] ~@body))
      (.start)))
 
 ;; from: https://github.com/MichaelBlume/ring-server/blob/master/src/ring/server/standalone.clj#L47
-(defn- add-destroy-hook
+(defn add-destroy-hook!
   "Add a destroy hook to be executed when the server ends."
   [server destroy]
   (in-thread
@@ -81,11 +84,11 @@
   (create-server! server)
   (create-nrepl-server! nrepl-server)
   (let [shutdown-hook (fn []
-                        (doseq [hook [destroy
+                        (doseq [hook [destroy!
                                       (fn [] (io/delete-file ".nrepl-port" true))]]
                           (hook)))]
-    (add-destroy-hook @server (. (Runtime/getRuntime)
-                                 (addShutdownHook (Thread. shutdown-hook))))))
+    (add-destroy-hook! @server (. (Runtime/getRuntime)
+                                  (addShutdownHook (Thread. shutdown-hook))))))
 
 #_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
 (defn before-ns-unload []

--- a/api/skulpture-eventing/project.clj
+++ b/api/skulpture-eventing/project.clj
@@ -16,7 +16,17 @@
                  [com.taoensso/truss "2.1.0"]
                  [metosin/spec-tools "0.10.7"]
                  [org.clojure/core.cache "1.1.234"]]
-  :profiles {:uberjar {:jvm-opts ["-Dclojure.compiler.direct-linking=true"]}
+  :profiles {:uberjar {:jvm-opts ["-Dclojure.compiler.direct-linking=true"]
+                       :uberjar-exclusions [#".*_test\.(clj|java)"]
+                       :aot :all
+                       :dependencies [[org.postgresql/postgresql "42.7.7" :scope "provided"]
+                                      [clj-test-containers/clj-test-containers "0.7.4" :scope "provided"]
+                                      [org.testcontainers/postgresql "1.21.2" :scope "provided"]
+                                      [metosin/jsonista "0.3.13" :scope "provided"]
+                                      [ring/ring-core "1.14.2" :scope "provided"]
+                                      [mount "0.1.23" :scope "provided"]
+                                      [com.zaxxer/HikariCP "6.3.0" :scope "provided"]
+                                      [migratus "1.6.4" :scope "provided"]]}
              :test {:env {:timbre-level "ERROR"
                           :log-level "ERROR"}
                     :dependencies [[org.postgresql/postgresql "42.7.7"]

--- a/api/skulpture-eventing/project.clj
+++ b/api/skulpture-eventing/project.clj
@@ -29,8 +29,9 @@
                                    [migratus "1.6.4"]]
                     :injections [(require 'clojure.set)]}}
   :test-paths ["src"]
-  :aliases {"build" ["uberjar"]
-            "build.watch" ["auto" "uberjar"]
+  :aliases {"build.prod" ["uberjar"]
+            "build.dev" ["do" "jar," "install"]
+            "build.watch" ["auto" "build.dev"]
             "test" ["test"]
             "test.watch" ["auto" "test"]}
   :test-selectors {:default (complement :integration)


### PR DESCRIPTION
before kicking off dev work thought would spend some time configuring everything so that it stops becoming the drag factor. without dev environment configured correctly its hard to develop effectively

changes:
- remove using ring's wrap reload middleware and instead using a custom one which explicitly shows when files have been reloaded
- reload namespaces when watched dirs change ✅ 
- nREPL server so we can jack in and inspect things ✅ 
- improvements to dev feedback loop
   - previously whenever projects were checked out, we need to include all the transitive deps inside the main project
   - migrate to using [lein-checkout-deps](https://github.com/rufoa/lein-checkout-deps) to just install all checked out projects so that we don't need to do this
   - the idea is that within a checked out project we can just run a `build.watch` which rebuilds that project for new changes. that will then cause the api project to reload during development because there has been changes to the checked out project which will cause all the namespaces to be reloaded and updated binaries imported
   - benefits are:
      - we don't need to fuss around with adding transitive deps to dev profiles
      - less errors during dev because everything is built correctly
      - closer to what a production build would be. dev workflow uses thin jars instead of uberjars
      - makes committing code a lot less annoying because we no longer need to comment and uncomment checked out dependencies
   - [lein-checkout-deps](https://github.com/rufoa/lein-checkout-deps) has not been updated in a while, but there's also nothing much to update. it's not so hard to fork it so I think should be fine
- everything is AOT now, for test files which are colocated we specify exclusions
   - there are some test dependencies which cause compilation to throw although they're excluded, specifying that those dependencies are provided fixes (kind of like extern modules when javascript bundling I think)

open issues:
- ~~think we need to remove `lein-ring` plugin and instead just run the jetty server ourselves~~
- ~~with the current `lein-ring` plugin there's still a compiler exception from the reloaded namespaces. this only happens when the namespace is a checked out module~~
- ~~I think `lein-ring` has is still wrapping the ring handler (`app`) in a `wrap-reload` which is causing the issue. I also think that if we specify checked out module paths to `wrap-reload` then things might work but I didn't try it and probably not going to because doing it custom allows us to see which files have changed which makes things a lot clearer~~
- ~~there's also a few additional things to configure: when editing the swagger definition for a route, the route itself is reloaded but we also need to reload the open api middleware so all the definitions get recalculated. the second part does not happen right now, swagger definitions do not change but the route is reloaded~~
- ~~import the deps for namespace reloading and nrepl at runtime so that we can move the deps to the dev profile~~
   - ~~considering running nrepl server in prod so we can connect to it and inspect things~~
   - ~~just need to (require) when fn is called instead of importing when defining the namespace~~
- ~~allow for configuring `PORT` and `NREPL_PORT`~~

new deps:
- https://github.com/tonsky/clj-reload
- https://github.com/ibdknox/watchtower
- https://github.com/clojure-emacs/cider-nrepl

stacktrace:
```
clojure.lang.Compiler$CompilerException: Syntax error compiling at (0:0).
                            core.clj:5920 clojure.core/throw-if
                            core.clj:5984 clojure.core/load-lib
                            core.clj:5981 clojure.core/load-lib
                          RestFn.java:145 clojure.lang.RestFn.applyTo
                             core.clj:669 clojure.core/apply
                            core.clj:6048 clojure.core/load-libs
                            core.clj:6028 clojure.core/load-libs
                          RestFn.java:140 clojure.lang.RestFn.applyTo
                             core.clj:669 clojure.core/apply
                            core.clj:6066 clojure.core/require
                            core.clj:6066 clojure.core/require
                          RestFn.java:424 clojure.lang.RestFn.invoke
                            reload.clj:17 ring.middleware.reload/reloader[fn]
                            reload.clj:38 ring.middleware.reload/wrap-reload[fn]
                        stacktrace.clj:27 ring.middleware.stacktrace/wrap-stacktrace-log[fn]
                        stacktrace.clj:99 ring.middleware.stacktrace/wrap-stacktrace-web[fn]
                             jetty.clj:25 ring.adapter.jetty/proxy-handler[fn]
                         (Unknown Source) ring.adapter.jetty.proxy$org.eclipse.jetty.server.handler.AbstractHandler$ff19274a.handle
                   HandlerWrapper.java:97 org.eclipse.jetty.server.handler.HandlerWrapper.handle
                          Server.java:499 org.eclipse.jetty.server.Server.handle
                     HttpChannel.java:311 org.eclipse.jetty.server.HttpChannel.handle
                  HttpConnection.java:258 org.eclipse.jetty.server.HttpConnection.onFillable
              AbstractConnection.java:544 org.eclipse.jetty.io.AbstractConnection$2.run
                QueuedThreadPool.java:635 org.eclipse.jetty.util.thread.QueuedThreadPool.runJob
                QueuedThreadPool.java:555 org.eclipse.jetty.util.thread.QueuedThreadPool$3.run
                         Thread.java:1583 java.lang.Thread.run
Caused by: java.lang.Exception: Found lib name 'skulpture-eventing.store.core' containing period with prefix 'quote'.  lib names inside prefix lists must not contain periods
```

demo of namespace reloads:

https://github.com/user-attachments/assets/a2593a4c-6085-411f-bb4e-dd67a1b85389

simplified dev workflow:

https://github.com/user-attachments/assets/0803a53c-bfac-4da8-b781-869fa1a87950

closes: #438 
