### PR TITLE
chore: setup tests in CI

### DIFF
--- a/.github/workflows/test-services.yml
+++ b/.github/workflows/test-services.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
-      - name: Test API
+      - name: Test skulpture-eventing
         working-directory: api/skulpture-eventing
         run: |
             docker compose -f docker-compose.test.yml up --exit-code-from skulpture-eventing
@@ -55,7 +55,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
-      - name: Test API
+      - name: Test imigresen-common
         working-directory: api/imigresen-common
         run: |
             docker compose -f docker-compose.test.yml up --exit-code-from imigresen-common
@@ -81,7 +81,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
-      - name: Test API
+      - name: Test imigresen-api
         working-directory: api/imigresen-api
         run: |
             docker compose -f docker-compose.test.yml up --exit-code-from imigresen-api

--- a/.github/workflows/test-services.yml
+++ b/.github/workflows/test-services.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Test API
         working-directory: api/skulpture-eventing
         run: |
-            docker compose -f docker-compose.test.yml up
+            docker compose -f docker-compose.test.yml up --exit-code-from skulpture-eventing
 
   test-common:
     runs-on: ubuntu-latest
@@ -58,7 +58,7 @@ jobs:
       - name: Test API
         working-directory: api/imigresen-common
         run: |
-            docker compose -f docker-compose.test.yml up
+            docker compose -f docker-compose.test.yml up --exit-code-from imigresen-common
 
   test-api:
     runs-on: ubuntu-latest
@@ -84,4 +84,4 @@ jobs:
       - name: Test API
         working-directory: api/imigresen-api
         run: |
-            docker compose -f docker-compose.test.yml up
+            docker compose -f docker-compose.test.yml up --exit-code-from imigresen-api

--- a/.github/workflows/test-services.yml
+++ b/.github/workflows/test-services.yml
@@ -1,0 +1,87 @@
+name: Test services
+
+on:
+  push:
+    branches: [master, staging, dev]
+  pull_request:
+    branches: [master, staging, dev]
+  workflow_dispatch:
+
+jobs:
+  test-eventing:
+    runs-on: ubuntu-latest
+
+    services:
+      docker:
+        image: docker:dind
+        options: --privileged --shm-size=2g
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock:ro
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Set up Docker Compose
+        uses: KengoTODA/actions-setup-docker-compose@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Test API
+        working-directory: api/skulpture-eventing
+        run: |
+            docker compose -f docker-compose.test.yml up
+
+  test-common:
+    runs-on: ubuntu-latest
+
+    services:
+      docker:
+        image: docker:dind
+        options: --privileged --shm-size=2g
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock:ro
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Set up Docker Compose
+        uses: KengoTODA/actions-setup-docker-compose@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Test API
+        working-directory: api/imigresen-common
+        run: |
+            docker compose -f docker-compose.test.yml up
+
+  test-api:
+    runs-on: ubuntu-latest
+
+    services:
+      docker:
+        image: docker:dind
+        options: --privileged --shm-size=2g
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock:ro
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Set up Docker Compose
+        uses: KengoTODA/actions-setup-docker-compose@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Test API
+        working-directory: api/imigresen-api
+        run: |
+            docker compose -f docker-compose.test.yml up

--- a/api/imigresen-api/docker-compose.test.yml
+++ b/api/imigresen-api/docker-compose.test.yml
@@ -1,7 +1,13 @@
 services:
   imigresen-api:
     image: clojure
-    command: sh -c "cd /skulpture-eventing && lein install && cd /imigresen-common && lein install && cd /imigresen-api && lein test"
+    command: >
+      sh -c "
+      cd /skulpture-eventing && 
+      lein install && 
+      cd /imigresen-common && 
+      lein install && 
+      cd /imigresen-api && lein cljfmt check && lein test"
     volumes:
       - .:/imigresen-api
       - ../imigresen-common:/imigresen-common

--- a/api/imigresen-api/docker-compose.test.yml
+++ b/api/imigresen-api/docker-compose.test.yml
@@ -9,3 +9,18 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
       JAVA_ENV: "test"
+      DB_MIGRATION_DIR: "migrations/"
+      DB_SEED_DIR: "seeds/"
+      DB_INIT_SCRIPT: "init.sql"
+      DB_INIT_IN_TRANSACTION: "false"
+      DB_MIGRATION_TABLE_NAME: "migrations"
+      DB_SEED_MIGRATION_TABLE_NAME: "seed_migrations"
+      # These are not really used, all mocked out
+      KC_AUTH_SERVER_URL: "https://authnz.skulpture.xyz"
+      KC_REALM: "imigresen-test"
+      KC_OAUTH_CLIENT_ID: "imigresen-test"
+      KC_OAUTH_CLIENT_SECRET: "NOT USED"
+      CF_R2_ACCESS_KEY: "NOT USED"
+      CF_R2_SECRET_KEY: "NOT USED"
+      CF_R2_ENDPOINT: "NOT USED"
+      ROLLOUT_URL: "https://rollout.skulpture.xyz"

--- a/api/imigresen-api/docker-compose.test.yml
+++ b/api/imigresen-api/docker-compose.test.yml
@@ -1,0 +1,11 @@
+services:
+  imigresen-api:
+    image: clojure
+    command: sh -c "cd /skulpture-eventing && lein install && cd /imigresen-common && lein install && cd /imigresen-api && lein test"
+    volumes:
+      - .:/imigresen-api
+      - ../imigresen-common:/imigresen-common
+      - ../skulpture-eventing:/skulpture-eventing
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      JAVA_ENV: "test"

--- a/api/skulpture-eventing/docker-compose.test.yml
+++ b/api/skulpture-eventing/docker-compose.test.yml
@@ -1,0 +1,9 @@
+services:
+  imigresen-api:
+    image: clojure
+    command: sh -c "cd /skulpture-eventing && lein test"
+    volumes:
+      - .:/skulpture-eventing
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      JAVA_ENV: "test"

--- a/api/skulpture-eventing/docker-compose.test.yml
+++ b/api/skulpture-eventing/docker-compose.test.yml
@@ -1,5 +1,5 @@
 services:
-  imigresen-api:
+  skulpture-eventing:
     image: clojure
     command: sh -c "cd /skulpture-eventing && lein test"
     volumes:

--- a/api/skulpture-eventing/docker-compose.test.yml
+++ b/api/skulpture-eventing/docker-compose.test.yml
@@ -1,7 +1,9 @@
 services:
   skulpture-eventing:
     image: clojure
-    command: sh -c "cd /skulpture-eventing && lein test"
+    command: >
+      sh -c "
+      cd /skulpture-eventing && lein cljfmt check && lein test"
     volumes:
       - .:/skulpture-eventing
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
DinD tests for all projects. CI tests are only run from this repo

notes:
- works locally but not 100% about whether DinD for the runner will run as expected
- running compose tests locally takes ages, think its because of arm emulation
- I think we can do this via `lein monolith` but kept them separate because different repos also

closes: #444 