### PR TITLE
chore(#450): fix container base image

### DIFF
--- a/api/imigresen-api/Dockerfile
+++ b/api/imigresen-api/Dockerfile
@@ -10,7 +10,7 @@ RUN cd skulpture-eventing && lein install
 RUN cd imigresen-common && lein install
 RUN cd imigresen-api && lein build.prod
 
-FROM eclipse-temurin:24-jre-alpine
+FROM eclipse-temurin:24-jdk-alpine
 
 # COPY --from=build /build/imigresen-common/target/common-SNAPSHOT-standalone.jar /app/common-standalone.jar
 COPY --from=build /build/imigresen-api/target/uberjar/api-0.1.0-SNAPSHOT-standalone.jar /app/api-standalone.jar


### PR DESCRIPTION
Clojure needs JDK tools to run, unsure why things were working fine when it was not AOT compiled

30 mb difference between base image sizes, so I think its fine

closes: #450 