### PR TITLE
chore(#440): yaml formatting

### DIFF
--- a/api/imigresen-api/docker-compose.dev.yml
+++ b/api/imigresen-api/docker-compose.dev.yml
@@ -1,96 +1,104 @@
 networks:
-  default:
-    name: imigresen
-    driver: overlay
-    attachable: true
+    default:
+        name: imigresen
+        driver: overlay
+        attachable: true
 
 secrets:
-  proxy.certificate:
-    file: ${PROXY_CERT_PATH}
-  proxy.key:
-    file: ${PROXY_KEY_PATH}
+    proxy.certificate:
+        file: ${PROXY_CERT_PATH}
+    proxy.key:
+        file: ${PROXY_KEY_PATH}
 
 services:
-  proxy:
-    image: traefik:v3.4
-    ports:
-      - target: 443
-        published: 443
-    deploy:
-      mode: replicated
-      replicas: 2
-      placement:
-        constraints:
-          - node.role == manager
-    command: >
-      --providers.swarm.endpoint=unix:///var/run/docker.sock --providers.swarm.exposedByDefault=false --providers.file.directory=/traefik --providers.file.watch=true --entryPoints.web.address=:80 --entryPoints.websecure.address=:443 --entryPoints.websecure.asDefault=true --entryPoints.web.http.redirections.entryPoint.to=websecure --entryPoints.web.http.redirections.entryPoint.scheme=https
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./traefik:/traefik
-    secrets:
-      - source: proxy.certificate
-        target: /certs/fullchain.pem
-      - source: proxy.key
-        target: /certs/privkey.pem
-    ulimits:
-      nofile:
-        soft: 20000
-        hard: 20000
+    proxy:
+        image: traefik:v3.4
+        ports:
+            - target: 443
+              published: 443
+        deploy:
+            mode: replicated
+            replicas: 2
+            placement:
+                constraints:
+                    - node.role == manager
+        command: >
+            --providers.swarm.endpoint=unix:///var/run/docker.sock
+             --providers.swarm.exposedByDefault=false
+             --providers.file.directory=/traefik
+             --providers.file.watch=true
+             --entryPoints.web.address=:80
+             --entryPoints.websecure.address=:443
+             --entryPoints.websecure.asDefault=true
+             --entryPoints.web.http.redirections.entryPoint.to=websecure
+             --entryPoints.web.http.redirections.entryPoint.scheme=https
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock
+            - ./traefik:/traefik
+        secrets:
+            - source: proxy.certificate
+              target: /certs/fullchain.pem
+            - source: proxy.key
+              target: /certs/privkey.pem
+        ulimits:
+            nofile:
+                soft: 20000
+                hard: 20000
 
-  imigresen-api-dev:
-    image: skulpture/imigresen-api:dev
-    environment:
-      LOG_LEVEL: ${LOG_LEVEL}
-      KC_AUTH_SERVER_URL: ${KC_AUTH_SERVER_URL}
-      KC_REALM: ${KC_REALM}
-      KC_OAUTH_CLIENT_ID: ${KC_OAUTH_CLIENT_ID}
-      KC_OAUTH_CLIENT_SECRET: ${KC_OAUTH_CLIENT_SECRET}
-      PG_CONNECTION_STRING: ${PG_CONNECTION_STRING}
-      DB_INIT_IN_TRANSACTION: ${DB_INIT_IN_TRANSACTION}
-      DB_MIGRATION_TABLE_NAME: ${DB_MIGRATION_TABLE_NAME}
-      DB_SEED_MIGRATION_TABLE_NAME: ${DB_SEED_MIGRATION_TABLE_NAME}
-      ROLLOUT_URL: ${ROLLOUT_URL}
-      OTEL_SERVICE_NAME: imigresen-api-dev
-      ENABLE_TELEMETRY: "${ENABLE_TELEMETRY}"
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
-      POSTMARK_TEMPLATE: ${POSTMARK_TEMPLATE_DEV}
-      POSTMARK_SERVER_TOKEN: ${POSTMARK_SERVER_TOKEN}
-      POSTMARK_ACCOUNT_TOKEN: ${POSTMARK_ACCOUNT_TOKEN}
-      JAVA_ENV: "development"
-      CF_R2_ACCESS_KEY: ${CF_R2_ACCESS_KEY}
-      CF_R2_SECRET_KEY: ${CF_R2_SECRET_KEY}
-      CF_R2_ENDPOINT: ${CF_R2_ENDPOINT}
-    deploy:
-      mode: replicated
-      replicas: 2
-      labels:
-        traefik.enable: "true"
-        traefik.http.routers.imigresen-api-dev.rule: Host(`api-dev.imigresen.skulpture.xyz`)
-        traefik.http.routers.imigresen-api-dev.tls.domains.main: imigresen.skulpture.xyz
-        traefik.http.routers.imigresen-api-dev.tls.domains.sans: "*.imigresen.skulpture.xyz"
-        traefik.http.services.imigresen-api-dev-service.loadbalancer.server.port: 3000
-        traefik.http.services.imigresen-api-dev-service.loadbalancer.server.scheme: http
-        traefik.http.services.imigresen-api-dev-service.loadbalancer.healthcheck.path: /ping
-        traefik.http.services.imigresen-api-dev-service.loadbalancer.healthcheck.status: 200
-        traefik.swarm.lbswarm: "true"
-    ulimits:
-      nofile:
-        soft: 20000
-        hard: 20000
-    healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/ping || exit 1" ]
-      interval: 1m30s
-      timeout: 1m
-      retries: 5
-      start_period: 3m
+    imigresen-api-dev:
+        image: skulpture/imigresen-api:dev
+        environment:
+            LOG_LEVEL: ${LOG_LEVEL}
+            KC_AUTH_SERVER_URL: ${KC_AUTH_SERVER_URL}
+            KC_REALM: ${KC_REALM}
+            KC_OAUTH_CLIENT_ID: ${KC_OAUTH_CLIENT_ID}
+            KC_OAUTH_CLIENT_SECRET: ${KC_OAUTH_CLIENT_SECRET}
+            PG_CONNECTION_STRING: ${PG_CONNECTION_STRING}
+            DB_INIT_IN_TRANSACTION: ${DB_INIT_IN_TRANSACTION}
+            DB_MIGRATION_TABLE_NAME: ${DB_MIGRATION_TABLE_NAME}
+            DB_SEED_MIGRATION_TABLE_NAME: ${DB_SEED_MIGRATION_TABLE_NAME}
+            ROLLOUT_URL: ${ROLLOUT_URL}
+            OTEL_SERVICE_NAME: imigresen-api-dev
+            ENABLE_TELEMETRY: "${ENABLE_TELEMETRY}"
+            OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+            POSTMARK_TEMPLATE: ${POSTMARK_TEMPLATE_DEV}
+            POSTMARK_SERVER_TOKEN: ${POSTMARK_SERVER_TOKEN}
+            POSTMARK_ACCOUNT_TOKEN: ${POSTMARK_ACCOUNT_TOKEN}
+            JAVA_ENV: "development"
+            CF_R2_ACCESS_KEY: ${CF_R2_ACCESS_KEY}
+            CF_R2_SECRET_KEY: ${CF_R2_SECRET_KEY}
+            CF_R2_ENDPOINT: ${CF_R2_ENDPOINT}
+        deploy:
+            mode: replicated
+            replicas: 2
+            labels:
+                traefik.enable: "true"
+                traefik.http.routers.imigresen-api-dev.rule: Host(`api-dev.imigresen.skulpture.xyz`)
+                traefik.http.routers.imigresen-api-dev.tls.domains.main: imigresen.skulpture.xyz
+                traefik.http.routers.imigresen-api-dev.tls.domains.sans: "*.imigresen.skulpture.xyz"
+                traefik.http.services.imigresen-api-dev-service.loadbalancer.server.port: 3000
+                traefik.http.services.imigresen-api-dev-service.loadbalancer.server.scheme: http
+                traefik.http.services.imigresen-api-dev-service.loadbalancer.healthcheck.path: /ping
+                traefik.http.services.imigresen-api-dev-service.loadbalancer.healthcheck.status: 200
+                traefik.swarm.lbswarm: "true"
+        ulimits:
+            nofile:
+                soft: 20000
+                hard: 20000
+        healthcheck:
+            test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/ping || exit 1" ]
+            interval: 1m30s
+            timeout: 1m
+            retries: 5
+            start_period: 3m
 
-  otel-collector:
-    image: otel/opentelemetry-collector-contrib
-    volumes:
-      - ./otel/collector-config.yml:/etc/otelcol-contrib/config.yaml
-    deploy:
-      mode: replicated
-      replicas: 1
-    environment:
-      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
-      OTEL_EXPORTER_OTLP_AUTH_TOKEN: ${OTEL_EXPORTER_OTLP_AUTH_TOKEN}
+    otel-collector:
+        image: otel/opentelemetry-collector-contrib
+        volumes:
+            - ./otel/collector-config.yml:/etc/otelcol-contrib/config.yaml
+        deploy:
+            mode: replicated
+            replicas: 1
+        environment:
+            OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            OTEL_EXPORTER_OTLP_AUTH_TOKEN: ${OTEL_EXPORTER_OTLP_AUTH_TOKEN}

--- a/api/imigresen-api/docker-compose.test.yml
+++ b/api/imigresen-api/docker-compose.test.yml
@@ -3,8 +3,8 @@ services:
         image: clojure
         command: >
             sh -c "
-             cd /skulpture-eventing && lein install
-             && cd /imigresen-common && lein install &&
+             cd /skulpture-eventing && lein install &&
+             cd /imigresen-common && lein install &&
              cd /imigresen-api && lein cljfmt check && lein clj-kondo && lein test"
         volumes:
             - .:/imigresen-api

--- a/api/imigresen-api/docker-compose.test.yml
+++ b/api/imigresen-api/docker-compose.test.yml
@@ -2,7 +2,10 @@ services:
     imigresen-api:
         image: clojure
         command: >
-            sh -c " cd /skulpture-eventing && lein install && cd /imigresen-common && lein install && cd /imigresen-api && lein cljfmt check && lein clj-kondo && lein test"
+            sh -c "
+             cd /skulpture-eventing && lein install
+             && cd /imigresen-common && lein install &&
+             cd /imigresen-api && lein cljfmt check && lein clj-kondo && lein test"
         volumes:
             - .:/imigresen-api
             - ../imigresen-common:/imigresen-common

--- a/api/skulpture-eventing/docker-compose.test.yml
+++ b/api/skulpture-eventing/docker-compose.test.yml
@@ -2,7 +2,7 @@ services:
     skulpture-eventing:
         image: clojure
         command: >
-            sh -c " cd /skulpture-eventing && lein cljfmt check && lein clj-kondo && lein test"
+            sh -c "cd /skulpture-eventing && lein cljfmt check && lein clj-kondo && lein test"
         volumes:
             - .:/skulpture-eventing
             - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
as part of #440, editorconfig was introduced but it also threw off the yaml formatting when it was a multiline

the lines would get folded although it was supposed to be multiline:
<img width="733" height="312" alt="image" src="https://github.com/user-attachments/assets/42809028-475e-442e-a2ac-236b9ba5aaac" />

instead of:
<img width="733" height="312" alt="image" src="https://github.com/user-attachments/assets/a82e7a55-bc53-44ed-9ca8-57b75acbf4d5" />

caused by VSCode extension: `EditorConfig.EditorConfig`

the fix seems to be prefixing the next line with a space:
<img width="733" height="312" alt="image" src="https://github.com/user-attachments/assets/370337e4-974f-4372-95cb-2146ed24b03a" />

couldn't find any specific settings to disable the behaviour:
<img width="733" height="312" alt="image" src="https://github.com/user-attachments/assets/91cd8c0a-45b2-4302-8044-31c7685d6b80" />

also yaml indent size is usually 2 spaces but I like 4