### PR TITLE
chore(#442): configure logging

### DIFF
--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -23,19 +23,22 @@
                  [ring/ring-jetty-adapter "1.14.2"]
                  [nrepl/nrepl "1.4.0"]
                  [cider/cider-nrepl "0.57.0"]
+                 [org.slf4j/slf4j-api "2.0.17"]
+                 [com.taoensso/telemere-slf4j "1.1.0"]
+                 [org.clojure/tools.logging "1.3.0"]
                  ;; lein monolith link imigresen/common
                  [imigresen/common "SNAPSHOT"]]
   :resource-paths ["resources"]
-
   :target-path "target/%s"
   :profiles {:dev {:env {:java-env "development"
-                         :taoensso-telemere-rt-min-level ":debug"}
+                         :taoensso-telemere-rt-min-level ":debug"
+                         :log-level "DEBUG"}
                    :main ^:skip-aot imigresen-api.app.server
                    :dependencies [[ring/ring-devel "1.14.1"]
                                   [io.github.tonsky/clj-reload "0.9.8"]
                                   [watchtower "0.1.1"]]}
              :uberjar {:env {:java-env "production"
-                             :timbre-level "ERROR"
+                             :taoensso-telemere-rt-min-level ":error"
                              :log-level "ERROR"}
                        :uberjar-exclusions [#".*_test\.(clj|java)"]
                        :aot :all


### PR DESCRIPTION
summary: configure logging so that everything is routed through telemere. also remove other slf4j providers present in the classpath

keycloak comes with `logback` which messes with telemere:
<img width="414" height="82" alt="image" src="https://github.com/user-attachments/assets/ea1a1244-0279-46b2-a4ee-9f146f447066" />

and also log4j12 was one of the deps in `imigresen-common`:
<img width="298" height="32" alt="image" src="https://github.com/user-attachments/assets/9550f2a2-ca8e-4527-8292-abbc6e5f9f03" />

java logging configured according to: https://github.com/taoensso/telemere/wiki/3-Config#java-logging

tools.logging configured according to: https://github.com/taoensso/telemere/wiki/3-Config#toolslogging

otel is already configured according to: https://github.com/taoensso/telemere/wiki/3-Config#opentelemetry

<img width="1047" height="92" alt="image" src="https://github.com/user-attachments/assets/13a9d211-638c-4715-b773-2edd178dfc1a" />

closes: #442 