### PR TITLE
chore(#462): swagger refresh auth token

### DIFF
--- a/api/imigresen-api/resources/swagger-ui/swagger-initializer.js
+++ b/api/imigresen-api/resources/swagger-ui/swagger-initializer.js
@@ -72,8 +72,7 @@ window.onload = function () {
 
             refreshIntervalId = setInterval(() => {
                 getNewAccessToken();
-            }, toMs(accessExpires - 10)
-            );
+            }, toMs(accessExpires - 10));
 
             return response;
         },

--- a/api/imigresen-api/resources/swagger-ui/swagger-initializer.js
+++ b/api/imigresen-api/resources/swagger-ui/swagger-initializer.js
@@ -1,7 +1,12 @@
 window.onload = function () {
     //<editor-fold desc="Changeable Configuration Block">
 
-    let token = "";
+    let accessToken = "";
+    let refreshToken = "";
+    let accessExpires = -1;
+    let refreshIntervalId;
+
+    const toMs = (seconds) => seconds * Math.pow(10, 3);
 
     // the following lines will be replaced by docker/configurator, when it runs in a docker-container
     window.ui = SwaggerUIBundle({
@@ -13,8 +18,8 @@ window.onload = function () {
             SwaggerUIStandalonePreset
         ],
         requestInterceptor: request => {
-            if (token) {
-                request.headers['Authorization'] = `Bearer ${token}`;
+            if (accessToken) {
+                request.headers['Authorization'] = `Bearer ${accessToken}`;
             }
 
             return request;
@@ -25,7 +30,38 @@ window.onload = function () {
             }
 
             const tokenParsed = response.body;
-            token = tokenParsed.access_token;
+            accessToken = tokenParsed.access_token;
+            refreshToken = tokenParsed.refresh_token;
+            accessExpires = tokenParsed.expires_in;
+
+            if (refreshIntervalId) {
+                clearInterval(refreshIntervalId);
+            }
+
+            const getNewAccessToken = async () => {
+                const res = await fetch('https://authnz.skulpture.xyz/realms/imigresen/protocol/openid-connect/token', {
+                    method: 'POST',
+                    body: new URLSearchParams({
+                        client_id: 'swagger',
+                        grant_type: 'refresh_token',
+                        refresh_token: refreshToken
+                    }),
+                });
+
+                const result = await res.json();
+
+                console.log('result', result);
+                if (res.ok) {
+                    accessToken = result.access_token;
+                    refreshToken = result.refresh_token;
+                    accessExpires = result.expires_in;
+                }
+            }
+
+            refreshIntervalId = setInterval(() => {
+                console.log('Here!! getNewAccessToken');
+                getNewAccessToken();
+            }, toMs(accessExpires - 5));
 
             return response;
         },

--- a/api/imigresen-api/resources/swagger-ui/swagger-initializer.js
+++ b/api/imigresen-api/resources/swagger-ui/swagger-initializer.js
@@ -11,7 +11,7 @@ window.onload = function () {
     // the following lines will be replaced by docker/configurator, when it runs in a docker-container
     window.ui = SwaggerUIBundle({
         url: "https://petstore.swagger.io/v2/swagger.json",
-        dom_id: '#swagger-ui',
+        dom_id: "#swagger-ui",
         deepLinking: true,
         presets: [
             SwaggerUIBundle.presets.apis,
@@ -19,7 +19,7 @@ window.onload = function () {
         ],
         requestInterceptor: request => {
             if (accessToken) {
-                request.headers['Authorization'] = `Bearer ${accessToken}`;
+                request.headers["Authorization"] = `Bearer ${accessToken}`;
             }
 
             return request;
@@ -38,30 +38,42 @@ window.onload = function () {
                 clearInterval(refreshIntervalId);
             }
 
-            const getNewAccessToken = async () => {
-                const res = await fetch('https://authnz.skulpture.xyz/realms/imigresen/protocol/openid-connect/token', {
-                    method: 'POST',
+            const getNewAccessToken = async (retryCount = 0) => {
+                // Not sure what causes this but sometimes the first request
+                // returns an error response saying that the session is not active
+                // The second request ends up being successful
+                // Unable to reproduce with a direct API request so not sure what's causing it
+                // might be the session state cookies which are present when we make a browser request
+                if (retryCount === 5) {
+                    throw new Error("Unable to refresh token");
+                }
+
+                console.debug("Refreshing access token", "retry count", retryCount);
+                const res = await fetch("https://authnz.skulpture.xyz/realms/imigresen/protocol/openid-connect/token", {
+                    method: "POST",
                     body: new URLSearchParams({
-                        client_id: 'swagger',
-                        grant_type: 'refresh_token',
+                        client_id: "swagger",
+                        grant_type: "refresh_token",
                         refresh_token: refreshToken
-                    }),
+                    })
                 });
 
                 const result = await res.json();
 
-                console.log('result', result);
+                console.debug("Refresh access token result", "ok?", res.ok, "result", result);
                 if (res.ok) {
                     accessToken = result.access_token;
                     refreshToken = result.refresh_token;
                     accessExpires = result.expires_in;
+                } else {
+                    getNewAccessToken(retryCount + 1);
                 }
             }
 
             refreshIntervalId = setInterval(() => {
-                console.log('Here!! getNewAccessToken');
                 getNewAccessToken();
-            }, toMs(accessExpires - 5));
+            }, toMs(accessExpires - 10)
+            );
 
             return response;
         },

--- a/api/imigresen-api/resources/swagger-ui/swagger-initializer.js
+++ b/api/imigresen-api/resources/swagger-ui/swagger-initializer.js
@@ -3,7 +3,7 @@ window.onload = function () {
 
     let accessToken = "";
     let refreshToken = "";
-    let accessExpires = -1;
+    let accessExpiresSeconds = -1;
     let refreshIntervalId;
 
     const toMs = (seconds) => seconds * Math.pow(10, 3);
@@ -32,7 +32,7 @@ window.onload = function () {
             const tokenParsed = response.body;
             accessToken = tokenParsed.access_token;
             refreshToken = tokenParsed.refresh_token;
-            accessExpires = tokenParsed.expires_in;
+            accessExpiresSeconds = tokenParsed.expires_in;
 
             if (refreshIntervalId) {
                 clearInterval(refreshIntervalId);
@@ -64,7 +64,9 @@ window.onload = function () {
                 if (res.ok) {
                     accessToken = result.access_token;
                     refreshToken = result.refresh_token;
-                    accessExpires = result.expires_in;
+                    accessExpiresSeconds = result.expires_in;
+
+                    console.debug("Access token refreshed next in (seconds)", accessExpiresSeconds)
                 } else {
                     getNewAccessToken(retryCount + 1);
                 }
@@ -72,7 +74,7 @@ window.onload = function () {
 
             refreshIntervalId = setInterval(() => {
                 getNewAccessToken();
-            }, toMs(accessExpires - 10));
+            }, toMs(accessExpiresSeconds - 10));
 
             return response;
         },


### PR DESCRIPTION
changes: get new access token in swagger before the current one expires

- no need for the entire keycloak client library, just make a request to the `/token` endpoint
- the IdP url is hardcoded but I think that's fine

docs: https://connect2id.com/products/server/docs/api/token#token-endpoint

<img width="1503" height="78" alt="image" src="https://github.com/user-attachments/assets/1871cfde-e9b4-4e84-a9d6-00e00ea0773f" />

closes: #462 