### PR TITLE
chore(#460): introduce typedclojure

### DIFF
--- a/api/imigresen-api/project.clj
+++ b/api/imigresen-api/project.clj
@@ -26,6 +26,7 @@
                  [org.slf4j/slf4j-api "2.0.17"]
                  [com.taoensso/telemere-slf4j "1.1.0"]
                  [org.clojure/tools.logging "1.3.0"]
+                 [org.typedclojure/typed.clj.runtime "1.3.0"]
                  ;; lein monolith link imigresen/common
                  [imigresen/common "SNAPSHOT"]]
   :resource-paths ["resources"]
@@ -36,12 +37,14 @@
                      :main ^:skip-aot imigresen-api.app.server
                      :dependencies [[ring/ring-devel "1.14.1"]
                                     [io.github.tonsky/clj-reload "0.9.8"]
-                                    [watchtower "0.1.1"]]}
+                                    [watchtower "0.1.1"]
+                                    [org.typedclojure/typed.clj.checker "1.3.0"]]}
              :dev {:env {:java-env "development"
                          :taoensso-telemere-rt-min-level ":debug"
                          :log-level "DEBUG"}
                    :main ^:skip-aot imigresen-api.app.server
-                   :dependencies [[ring/ring-devel "1.14.1"]]}
+                   :dependencies [[ring/ring-devel "1.14.1"]
+                                  [org.typedclojure/typed.clj.checker "1.3.0"]]}
              :uberjar {:env {:java-env "production"
                              :taoensso-telemere-rt-min-level ":error"
                              :log-level "ERROR"}
@@ -58,7 +61,8 @@
                             :java-env "test"}
                       :dependencies [[lambdaisland/kaocha "1.91.1392"]
                                      [org.clojure/data.json "2.5.1"]
-                                     [ring/ring-mock "0.6.1"]]}}
+                                     [ring/ring-mock "0.6.1"]
+                                     [org.typedclojure/typed.clj.checker "1.3.0"]]}}
   :plugins [[lein-environ "LATEST"]
             [lein-auto "LATEST"]
             [migratus-lein "0.7.3"]

--- a/api/skulpture-eventing/project.clj
+++ b/api/skulpture-eventing/project.clj
@@ -16,7 +16,8 @@
                  [clojure.java-time "1.4.3"]
                  [com.taoensso/truss "2.1.0"]
                  [metosin/spec-tools "0.10.7"]
-                 [org.clojure/core.cache "1.1.234"]]
+                 [org.clojure/core.cache "1.1.234"]
+                 [org.typedclojure/typed.clj.runtime "1.3.0"]]
   :profiles {:uberjar {:jvm-opts ["-Dclojure.compiler.direct-linking=true"]
                        :uberjar-exclusions [#".*_test\.(clj|java)"]
                        :aot :all
@@ -39,7 +40,8 @@
                                      [ring/ring-core "1.14.2"]
                                      [mount "0.1.23"]
                                      [com.zaxxer/HikariCP "6.3.0"]
-                                     [migratus "1.6.4"]]
+                                     [migratus "1.6.4"]
+                                     [org.typedclojure/typed.clj.checker "1.3.0"]]
                       :injections [(require 'clojure.set)]}}
   :test-paths ["src"]
   :cljfmt {:load-config-file? true}


### PR DESCRIPTION
changes: introduce `typedclojure` into projects, doesn't setup anything else for running type checks during dev. can handle later. a repl to manually run type checks when required is fine for now

related: #460 