### PR TITLE
refactor(#462): swagger refresh auth token

### DIFF
--- a/api/imigresen-api/resources/swagger-ui/swagger-initializer.js
+++ b/api/imigresen-api/resources/swagger-ui/swagger-initializer.js
@@ -1,42 +1,32 @@
 window.onload = function () {
     //<editor-fold desc="Changeable Configuration Block">
 
-    let accessToken = "";
-    let refreshToken = "";
-    let accessExpiresSeconds = -1;
-    let refreshIntervalId;
+    class Keycloak {
+        accessToken = "";
+        #refreshToken = "";
+        #accessExpiresSeconds = -1;
+        #refreshIntervalId = null;
 
-    const toMs = (seconds) => seconds * Math.pow(10, 3);
+        #tokenEndpoint = "https://authnz.skulpture.xyz/realms/imigresen/protocol/openid-connect/token";
 
-    // the following lines will be replaced by docker/configurator, when it runs in a docker-container
-    window.ui = SwaggerUIBundle({
-        url: "https://petstore.swagger.io/v2/swagger.json",
-        dom_id: "#swagger-ui",
-        deepLinking: true,
-        presets: [
-            SwaggerUIBundle.presets.apis,
-            SwaggerUIStandalonePreset
-        ],
-        requestInterceptor: request => {
-            if (accessToken) {
-                request.headers["Authorization"] = `Bearer ${accessToken}`;
+        init(authenticatedResponse) {
+            this.accessToken = authenticatedResponse.access_token;
+            this.#refreshToken = authenticatedResponse.refresh_token;
+            this.#accessExpiresSeconds = authenticatedResponse.expires_in;
+
+            this.#refreshAccessToken();
+        }
+
+        #refreshAccessToken() {
+            if (this.#refreshIntervalId) {
+                clearInterval(this.#refreshIntervalId);
             }
 
-            return request;
-        },
-        responseInterceptor: async (response) => {
-            if (response.body.token_type !== "Bearer") {
-                return response;
+            if (!this.accessToken || !this.#refreshToken || !~this.#accessExpiresSeconds) {
+                throw new Error("Unable to refresh tokens, must be authenticated first");
             }
 
-            const tokenParsed = response.body;
-            accessToken = tokenParsed.access_token;
-            refreshToken = tokenParsed.refresh_token;
-            accessExpiresSeconds = tokenParsed.expires_in;
-
-            if (refreshIntervalId) {
-                clearInterval(refreshIntervalId);
-            }
+            const toMs = (seconds) => seconds * Math.pow(10, 3);
 
             const getNewAccessToken = async (retryCount = 0) => {
                 // Not sure what causes this but sometimes the first request
@@ -49,32 +39,65 @@ window.onload = function () {
                 }
 
                 console.debug("Refreshing access token", "retry count", retryCount);
-                const res = await fetch("https://authnz.skulpture.xyz/realms/imigresen/protocol/openid-connect/token", {
+
+                const res = await fetch(this.#tokenEndpoint, {
                     method: "POST",
                     body: new URLSearchParams({
                         client_id: "swagger",
                         grant_type: "refresh_token",
-                        refresh_token: refreshToken
+                        refresh_token: this.#refreshToken
                     })
                 });
 
                 const result = await res.json();
 
                 console.debug("Refresh access token result", "ok?", res.ok, "result", result);
-                if (res.ok) {
-                    accessToken = result.access_token;
-                    refreshToken = result.refresh_token;
-                    accessExpiresSeconds = result.expires_in;
-
-                    console.debug("Access token refreshed next in (seconds)", accessExpiresSeconds)
-                } else {
-                    getNewAccessToken(retryCount + 1);
+                if (!res.ok) {
+                    return getNewAccessToken(retryCount + 1);
                 }
+
+                this.accessToken = result.access_token;
+                this.#refreshToken = result.refresh_token;
+                this.#accessExpiresSeconds = result.expires_in;
+
+                console.debug("Access token refreshed next in (seconds)", this.accessToken);
             }
 
-            refreshIntervalId = setInterval(() => {
+            this.#refreshIntervalId = setInterval(() => {
                 getNewAccessToken();
-            }, toMs(accessExpiresSeconds - 10));
+            }, toMs(this.#accessExpiresSeconds - 10));
+        }
+
+        static isAuthenticatedResponse(authenticatedResponse) {
+            return authenticatedResponse?.token_type === "Bearer";
+        }
+    }
+
+    const kc = new Keycloak();
+
+    // the following lines will be replaced by docker/configurator, when it runs in a docker-container
+    window.ui = SwaggerUIBundle({
+        url: "https://petstore.swagger.io/v2/swagger.json",
+        dom_id: "#swagger-ui",
+        deepLinking: true,
+        displayRequestDuration: true,
+        presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIStandalonePreset
+        ],
+        requestInterceptor: request => {
+            if (kc.accessToken) {
+                request.headers["Authorization"] = `Bearer ${kc.accessToken}`;
+            }
+
+            return request;
+        },
+        responseInterceptor: async (response) => {
+            if (!Keycloak.isAuthenticatedResponse(response.body)) {
+                return response;
+            }
+
+            kc.init(response.body);
 
             return response;
         },


### PR DESCRIPTION
refactor of initial implementation for #462: #468 

also updated swagger config to display response duration:

<img width="1503" height="292" alt="image" src="https://github.com/user-attachments/assets/4bbc230e-34ab-4c90-adc6-af66db3031e9" />
