### PR TITLE
feat(#434): kobalte combobox

### DIFF
--- a/client/src/ui/combobox/combobox.stories.tsx
+++ b/client/src/ui/combobox/combobox.stories.tsx
@@ -1,4 +1,5 @@
-import { createMemo, createSignal, For } from "solid-js";
+import { createFilter } from "@kobalte/core";
+import { createSignal, type JSX } from "solid-js";
 import type { Meta, StoryObj as Story } from "storybook-solidjs";
 import {
 	Combobox,
@@ -6,8 +7,6 @@ import {
 	ComboboxInput,
 	ComboboxItem,
 	ComboboxTrigger,
-	createListCollection,
-	type ComboboxInputValueChangeDetails,
 } from "ui/combobox";
 
 export default {
@@ -32,39 +31,40 @@ export const Default: Story<typeof Combobox> = {
 			"SolidStart",
 			"Nuxt.js",
 		];
-		const [items, setItems] = createSignal(initialItems);
-		const collection = createMemo(() =>
-			createListCollection({ items: items() }),
-		);
+		const [items, setItems] = createSignal<string[]>([]);
 
-		const handleInputChange = (
-			details: ComboboxInputValueChangeDetails,
-		) => {
+		const filter = createFilter({ sensitivity: "base" });
+		const handleInputChange: JSX.ChangeEventHandler<
+			HTMLSelectElement,
+			Event
+		> = event => {
+			const options = [...event.target.options]
+				.filter(option => option.selected)
+				.map(option => option.value);
+
 			setItems(
 				initialItems.filter(item =>
-					item
-						.toLowerCase()
-						.includes(details.inputValue.toLowerCase()),
+					options.some(value => filter.contains(item, value)),
 				),
 			);
 		};
 
 		return (
 			<Combobox
-				collection={collection()}
+				options={initialItems}
 				placeholder="Search framework..."
-				onInputValueChange={handleInputChange}>
+				value={items()}
+				onChange={handleInputChange}
+				itemComponent={props => (
+					<ComboboxItem item={props.item}>
+						{props.item.rawValue}
+					</ComboboxItem>
+				)}>
 				<ComboboxTrigger>
 					<ComboboxInput />
 				</ComboboxTrigger>
 
-				<ComboboxContent>
-					<For each={collection().items}>
-						{item => (
-							<ComboboxItem item={item}>{item}</ComboboxItem>
-						)}
-					</For>
-				</ComboboxContent>
+				<ComboboxContent />
 			</Combobox>
 		);
 	},

--- a/client/src/ui/combobox/index.tsx
+++ b/client/src/ui/combobox/index.tsx
@@ -1,165 +1,207 @@
 import {
 	Combobox as ComboboxPrimitive,
-	createListCollection as arkCreateListCollection,
-} from "@ark-ui/solid/combobox";
-import { spreadProps } from "core/utils";
-import { Check, ChevronsDownUp, X } from "lucide-solid";
-import { children, type Component, type ParentProps } from "solid-js";
-import { Portal } from "solid-js/web";
+	type ComboboxContentProps,
+	type ComboboxInputProps,
+	type ComboboxItemProps,
+	type ComboboxRootProps,
+	type ComboboxTriggerProps,
+} from "@kobalte/core/combobox";
+import type { PolymorphicProps } from "@kobalte/core/polymorphic";
+import { Check, ChevronsUpDown, X } from "lucide-solid";
+import {
+	createSignal,
+	splitProps,
+	type Component,
+	type JSX,
+	type ParentProps,
+	type ValidComponent,
+	type VoidProps,
+} from "solid-js";
 import { cn } from "ui/utils";
 
-export const resources = {
-	triggerSrOnly: "Expand",
-	itemCheckedSrOnly: "Selected",
-};
+export const ComboboxHiddenSelect = ComboboxPrimitive.HiddenSelect;
 
-export type {
-	ComboboxInputValueChangeDetails,
-	ComboboxSelectionDetails,
-} from "@ark-ui/solid/combobox";
+export type ComboboxProps<
+	Option,
+	OptGroup = never,
+	T extends ValidComponent = "div",
+> = Omit<
+	ComboboxRootProps<Option, OptGroup, T>,
+	"ref" | "onInput" | "onChange" | "onBlur"
+> &
+	Pick<
+		JSX.SelectHTMLAttributes<HTMLSelectElement>,
+		"ref" | "onInput" | "onChange" | "onBlur"
+	>;
 
-export const createListCollection = arkCreateListCollection;
-
-export interface ComboboxProps<TCollection extends string | Record<string, any>>
-	extends Omit<ComboboxPrimitive.RootProps<TCollection>, "value"> {
-	value?: string | string[];
-}
-
-export const Combobox = <TCollection extends string | Record<string, any>>(
-	props: ComboboxProps<TCollection>,
+export const Combobox = <
+	Option,
+	OptGroup = never,
+	T extends ValidComponent = "div",
+>(
+	props: PolymorphicProps<T, ComboboxProps<Option, OptGroup, T>>,
 ) => {
-	const getValue = (props: ComboboxProps<TCollection>) => {
-		if (!props.value) {
-			return [];
-		}
-
-		if (Array.isArray(props.value)) {
-			return props.value;
-		}
-
-		return [props.value];
-	};
+	const [value, setValue] = createSignal(props.value);
+	const [comboboxProps, others] = splitProps(props, [
+		"ref",
+		"onInput",
+		"onChange",
+		"onBlur",
+	]);
 
 	return (
-		<ComboboxPrimitive.Root
-			{...spreadProps(props)}
-			value={getValue(props)}
+		<ComboboxPrimitive {...others} value={value()} onChange={setValue}>
+			{props.children}
+
+			<ComboboxHiddenSelect {...comboboxProps} />
+		</ComboboxPrimitive>
+	);
+};
+
+export const ComboboxDescription = ComboboxPrimitive.Description;
+export const ComboboxErrorMessage = ComboboxPrimitive.ErrorMessage;
+export const ComboboxItemDescription = ComboboxPrimitive.ItemDescription;
+
+type comboboxInputProps<T extends ValidComponent = "input"> = VoidProps<
+	ComboboxInputProps<T> & {
+		class?: string;
+	}
+>;
+
+export const ComboboxInput = <T extends ValidComponent = "input">(
+	props: PolymorphicProps<T, comboboxInputProps<T>>,
+) => {
+	const [local, rest] = splitProps(props as comboboxInputProps, ["class"]);
+
+	return (
+		<ComboboxPrimitive.Input
+			class={cn(
+				"h-full bg-transparent text-sm placeholder:text-muted-foreground",
+				"focus:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+				"border-0 focus:ring-0",
+				local.class,
+			)}
+			{...rest}
 		/>
 	);
 };
 
-export const ComboboxItemGroup = ComboboxPrimitive.ItemGroup;
+type comboboxTriggerProps<T extends ValidComponent = "button"> = ParentProps<
+	ComboboxTriggerProps<T> & {
+		class?: string;
+	}
+>;
 
-export const ComboxboxItemGroupLabel = (
-	props: ComboboxPrimitive.ItemGroupLabelProps,
-) => (
-	<ComboboxPrimitive.ItemGroupLabel
-		{...spreadProps(props)}
-		class={cn("text-sm font-bold py-1.5 pr-2 pl-8", props.class)}>
-		{props.children}
-	</ComboboxPrimitive.ItemGroupLabel>
-);
-
-export const ComboboxInput = (props: ComboboxPrimitive.InputProps) => (
-	<ComboboxPrimitive.Input
-		{...spreadProps(props)}
-		ref={props.ref}
-		class={cn(
-			"h-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none",
-			"border-0 focus:border-0 focus:shadow-none focus:ring-0",
-			"disabled:cursor-not-allowed disabled:opacity-50 w-full",
-			props.class,
-		)}
-	/>
-);
-
-export const ComboboxTrigger = (props: ComboboxPrimitive.TriggerProps) => (
-	<ComboboxPrimitive.Control>
-		<ComboboxPrimitive.Trigger
-			{...spreadProps(props)}
-			ref={props.ref}
-			class={cn(
-				"relative flex h-10 w-full items-center justify-between rounded-md border border-input px-3 has-[:focus-visible]:ring-2",
-				"has-[:focus-visible]:ring-ring has-[:focus-visible]:ring-offset-2 transition has-[:focus-visible]:ring-offset-background",
-				"disabled:cursor-not-allowed disabled:opacity-50",
-				props.class,
-			)}>
-			{props.children}
-
-			<div class="flex h-3.5 w-3.5 items-center justify-center text-muted-foreground">
-				<ChevronsDownUp class="h-4 w-4">
-					<span class="sr-only">{resources.triggerSrOnly}</span>
-				</ChevronsDownUp>
-			</div>
-		</ComboboxPrimitive.Trigger>
-	</ComboboxPrimitive.Control>
-);
-
-export const ComboboxContent = (props: ComboboxPrimitive.ContentProps) => {
-	const getChildren = children(() => props.children);
+export const ComboboxTrigger = <T extends ValidComponent = "button">(
+	props: PolymorphicProps<T, comboboxTriggerProps<T>>,
+) => {
+	const [local, rest] = splitProps(props as comboboxTriggerProps, [
+		"class",
+		"children",
+	]);
 
 	return (
-		<Portal>
-			<ComboboxPrimitive.Positioner>
-				<ComboboxPrimitive.Content
-					{...spreadProps(props)}
-					ref={props.ref}
-					class={cn(
-						"relative z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground",
-						'shadow-md data-[state="open"]:animate-in data-[state="closed"]:animate-out data-[state="closed"]:fade-out-0',
-						'data-[state="open"]:fade-in-0 data-[state="closed"]:zoom-out-95 data-[state="open"]:zoom-in-95',
-						"max-h-[50vh] overflow-scroll",
-						(getChildren() as unknown[]).length > 0
-							? "visible"
-							: "hidden",
-						props.class,
-					)}>
-					<div class="p-1">{props.children}</div>
-				</ComboboxPrimitive.Content>
-			</ComboboxPrimitive.Positioner>
-		</Portal>
+		<ComboboxPrimitive.Control>
+			<ComboboxPrimitive.Trigger
+				class={cn(
+					"flex h-9 w-full items-center justify-between rounded-md border border-input px-3 shadow-sm",
+					"focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:outline-none ring-offset-background",
+					local.class,
+				)}
+				{...rest}>
+				{local.children}
+				<ComboboxPrimitive.Icon class="flex h-3.5 w-3.5 items-center justify-center">
+					<ChevronsUpDown class="size-4 opacity-50" />
+				</ComboboxPrimitive.Icon>
+			</ComboboxPrimitive.Trigger>
+		</ComboboxPrimitive.Control>
 	);
 };
 
-export const ComboboxItem = (props: ComboboxPrimitive.ItemProps) => (
-	<ComboboxPrimitive.Item
-		{...spreadProps(props)}
-		ref={props.ref}
-		class={cn(
-			"relative h-10 flex w-full cursor-default select-none items-center rounded-sm py-1.5 pr-2 pl-8",
-			"text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent",
-			"data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50",
-			props.class,
-		)}>
-		<ComboboxPrimitive.ItemIndicator
-			class={cn(
-				"absolute left-2 flex h-3.5 w-3.5 items-center justify-center text-foreground",
-				"data-[highlighted]:text-accent-foreground",
-			)}>
-			<Check class="h-4 w-4">
-				<span class="sr-only">{resources.itemCheckedSrOnly}</span>
-			</Check>
-		</ComboboxPrimitive.ItemIndicator>
+type comboboxContentProps<T extends ValidComponent = "div"> =
+	ComboboxContentProps<T> & {
+		class?: string;
+	};
 
-		<ComboboxPrimitive.ItemText>
-			{props.children}
-		</ComboboxPrimitive.ItemText>
-	</ComboboxPrimitive.Item>
-);
+export const ComboboxContent = <T extends ValidComponent = "div">(
+	props: PolymorphicProps<T, comboboxContentProps<T>>,
+) => {
+	const [local, rest] = splitProps(props as comboboxContentProps, ["class"]);
+
+	return (
+		<ComboboxPrimitive.Portal>
+			<ComboboxPrimitive.Content
+				class={cn(
+					"relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover",
+					"text-popover-foreground shadow-md data-[expanded]:animate-in",
+					"data-[closed]:animate-out data-[closed]:fade-out-0 data-[expanded]:fade-in-0",
+					"data-[closed]:zoom-out-95 data-[expanded]:zoom-in-95",
+					"origin-[--kb-combobox-content-transform-origin]",
+					local.class,
+				)}
+				{...rest}>
+				<ComboboxPrimitive.Listbox class="p-1" />
+			</ComboboxPrimitive.Content>
+		</ComboboxPrimitive.Portal>
+	);
+};
+
+type comboboxItemProps<T extends ValidComponent = "li"> = ParentProps<
+	ComboboxItemProps<T> & {
+		class?: string;
+	}
+>;
+
+export const ComboboxItem = <T extends ValidComponent = "li">(
+	props: PolymorphicProps<T, comboboxItemProps<T>>,
+) => {
+	const [local, rest] = splitProps(props as comboboxItemProps, [
+		"class",
+		"children",
+	]);
+
+	return (
+		<ComboboxPrimitive.Item
+			class={cn(
+				"relative flex w-full cursor-default select-none items-center rounded-sm",
+				"py-1.5 pl-2 pr-8 text-sm outline-none data-[disabled]:pointer-events-none",
+				"data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground",
+				"data-[disabled]:opacity-50",
+				local.class,
+			)}
+			{...rest}>
+			<ComboboxPrimitive.ItemIndicator class="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+				<Check class="size-4" />
+			</ComboboxPrimitive.ItemIndicator>
+			<ComboboxPrimitive.ItemLabel>
+				{local.children}
+			</ComboboxPrimitive.ItemLabel>
+		</ComboboxPrimitive.Item>
+	);
+};
+
+export interface ComboboxClearSelectionProps {
+	onClear: () => void;
+}
 
 export const ComboboxClearSelection: Component<
-	ParentProps<ComboboxPrimitive.ClearTriggerProps>
+	ComboboxClearSelectionProps
 > = props => {
+	const onPointerDown = (event: MouseEvent) => {
+		event.stopImmediatePropagation();
+	};
+
 	return (
-		<ComboboxPrimitive.ClearTrigger
-			{...spreadProps(props)}
+		<button
 			class={cn(
-				"absolute right-8 top-[30%] cursor-pointer",
-				"focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring focus:outline-none",
-				"focus-visible:ring-offset-background",
-				props.class,
-			)}>
+				"absolute right-8 top-[30%] bg-muted cursor-pointer",
+				"focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring",
+				"focus:outline-none focus-visible:ring-offset-background",
+			)}
+			onPointerDown={onPointerDown}
+			onClick={props.onClear}
+			tabIndex={0}>
 			<X class="size-4 p-0.5 text-muted-foreground transition hover:text-foreground" />
-		</ComboboxPrimitive.ClearTrigger>
+		</button>
 	);
 };

--- a/client/src/ui/select/index.tsx
+++ b/client/src/ui/select/index.tsx
@@ -79,8 +79,8 @@ export const SelectTrigger = <T extends ValidComponent = "button">(
 		{...spreadProps(props)}
 		class={cn(
 			"flex h-10 w-full items-center justify-between rounded-md border border-input bg-background",
-			"px-3 py-2 text-sm text-foreground ring-offset-background placeholder:text-muted-foreground focus:outline-none",
-			"focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed",
+			"px-3 py-2 text-sm text-foreground ring-offset-background placeholder:text-muted-foreground focus-within:outline-none",
+			"focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 disabled:cursor-not-allowed",
 			"disabled:opacity-50 [&>span]:line-clamp-1 transition-shadow relative",
 			props.class,
 		)}>


### PR DESCRIPTION
changes: migrate from using ark ui combobox base to kobalte combobox base because ark ui's version does not have a hidden select which allows for treating it like a native component

iirc started with kobalte then switched to ark ui because it has support for custom values. now we don't need custom values anymore so switch back to kobalte. it works better with modular forms because all `onChange` for it must have an event as params

address autocomplete relies on having custom values + ability to dynamically update options, think kobalte does not update options very well, the option list is empty because it is initialised as an empty array for address autocomplete and does not update when suggestions are populated

if still can't get it to work then need to bring hidden input to ark ui, it's not trivial because:
- a combobox is a html text input + select
- when testing the html text input emits change events like we would expect it to but when an existing option is selected we have to use `onSelect`. so there are two props that we need to listen for
- it doesn't work with modular forms because it only has 1 `onChange`
- so we need to add a custom hidden select which has changes from both sources and then also ensure that events are emitted correctly and that if we do `new FormData(form)` that everything is correct
   - maybe we can just create an event manually and send it along, all we care about is that its a Dom `Event` with values

related:
- issue with kobalte from last time: https://github.com/kobaltedev/kobalte/issues/599#issuecomment-3379233745

TODO:
- migrate all existing pages
