### PR TITLE
chore: fix api healthcheck

### DIFF
--- a/api/imigresen-api/docker-compose.dev.yml
+++ b/api/imigresen-api/docker-compose.dev.yml
@@ -87,7 +87,7 @@ services:
                 soft: 20000
                 hard: 20000
         healthcheck:
-            test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/ping || exit 1" ]
+            test: [ "CMD-SHELL", "wget --no-verbose --tries=1 http://localhost:3000/ping || exit 1" ]
             interval: 1m30s
             timeout: 1m
             retries: 5


### PR DESCRIPTION
https://unix.stackexchange.com/questions/513749/wget-spider-fails-with-404-but-works-without-spider

`apk update` introduced in  #518 seems to have broken the existing healthcheck

<img width="579" height="83" alt="image" src="https://github.com/user-attachments/assets/749fa976-9b6c-4d80-973f-e6b480cc22a4" />
