### PR TITLE
refactor: user svc - handle errors better, refactor how we handle state

### DIFF
--- a/client/src/core/context/initializers.ts
+++ b/client/src/core/context/initializers.ts
@@ -61,7 +61,7 @@ export const createUserContext = (): UserSvc => ({
 	isInitialLoading: true,
 	profile: null,
 	actions: {
-		init: noop,
+		init: noop as any,
 		completeSync: noop,
 	},
 });

--- a/client/src/core/context/user/provider.tsx
+++ b/client/src/core/context/user/provider.tsx
@@ -1,40 +1,137 @@
+import { useQueryClient } from "@tanstack/solid-query";
 import { AuthnContext } from "core/context/authn";
 import { createUserContext } from "core/context/initializers";
 import { useContext } from "core/context/utils";
 import {
 	createContext,
+	ErrorBoundary,
 	getOwner,
-	onMount,
 	runWithOwner,
 	Show,
 	type Accessor,
 	type Component,
 	type ParentProps,
 } from "solid-js";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogClose,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "ui/alert-dialog";
+import { resources } from "./resources";
 import { useStore, type UserSvc } from "./store";
 
 export const UserContext = createContext<Accessor<UserSvc>>(createUserContext);
 
-export const UserProvider: Component<ParentProps> = props => {
-	const value = useStore();
-	const authnContext = useContext(AuthnContext);
+interface TrackProps {
+	fn?: () => Promise<void>;
+}
+
+const Track: Component<TrackProps> = props => {
 	const owner = getOwner();
 
-	onMount(() => {
+	// workaround to make error boundaries catch errors which occur async (event handlers, setTimeout)
+	// `fn` must be async. if its sync which calls an async function (which throws) then the error
+	// will not propagate correctly
+	// based on: https://github.com/solidjs/solid/discussions/1174
+	props.fn?.().catch(err =>
+		runWithOwner(owner, () => {
+			throw err;
+		}),
+	);
+
+	return null;
+};
+
+const UserProviderWithoutErrorBoundary: Component<ParentProps> = props => {
+	const queryClient = useQueryClient();
+	const authnContext = useContext(AuthnContext);
+
+	const value = useStore({ queryClient });
+
+	const onMount = async () => {
 		if (authnContext().isInitialLoading) {
 			return;
 		}
 
 		const profile = authnContext().profile;
 
-		runWithOwner(owner, () =>
-			value().actions.init(authnContext().keycloak?.token, profile),
-		);
-	});
+		return value().actions.init(authnContext().keycloak?.token, profile);
+	};
 
 	return (
-		<UserContext.Provider value={value}>
-			<Show when={!value().isInitialLoading}>{props.children}</Show>
-		</UserContext.Provider>
+		<>
+			<Track fn={onMount} />
+			<UserContext.Provider value={value}>
+				<Show when={!value().isInitialLoading}>{props.children}</Show>
+			</UserContext.Provider>
+		</>
+	);
+};
+
+export const UserProvider: Component<ParentProps> = props => {
+	const authnContext = useContext(AuthnContext);
+	const onClickOk = () => authnContext().actions.logout();
+
+	return (
+		<UserErrorBoundary onClickOk={onClickOk}>
+			<UserProviderWithoutErrorBoundary>
+				{props.children}
+			</UserProviderWithoutErrorBoundary>
+		</UserErrorBoundary>
+	);
+};
+
+interface UserErrorBoundaryProps {
+	onClickOk?: () => void;
+}
+
+interface FallbackProps {
+	err: any;
+	reset: () => void;
+}
+
+const UserErrorBoundary: Component<
+	ParentProps<UserErrorBoundaryProps>
+> = props => {
+	const Fallback: Component<FallbackProps> = fallbackProps => {
+		const onClickOk = () => {
+			fallbackProps.reset();
+			props.onClickOk?.();
+		};
+
+		return (
+			<AlertDialog defaultOpen>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>
+							{resources.errorBoundary.title}
+						</AlertDialogTitle>
+						<AlertDialogDescription>
+							{resources.errorBoundary.description}
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogClose onClick={onClickOk}>
+							{resources.errorBoundary.doCancel}
+						</AlertDialogClose>
+						<AlertDialogAction onClick={onClickOk}>
+							{resources.errorBoundary.doOk}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		);
+	};
+
+	return (
+		<ErrorBoundary
+			fallback={(err, reset) => <Fallback err={err} reset={reset} />}>
+			{props.children}
+		</ErrorBoundary>
 	);
 };

--- a/client/src/core/context/user/resources.ts
+++ b/client/src/core/context/user/resources.ts
@@ -1,0 +1,9 @@
+export const resources = {
+	errorBoundary: {
+		title: "An unexpected error occurred",
+		description:
+			"Unable to initialize application. Please contact support.",
+		doOk: "Ok",
+		doCancel: "Cancel",
+	},
+};

--- a/client/src/core/context/user/store/index.ts
+++ b/client/src/core/context/user/store/index.ts
@@ -1,9 +1,8 @@
-import { useQuery } from "@tanstack/solid-query";
+import { QueryClient } from "@tanstack/solid-query";
 import { queryKeys } from "core/constants/query-keys";
 import { normalizeResponse } from "core/data/transform-deep";
 import { invariant, once } from "es-toolkit";
 import type { KeycloakProfile } from "keycloak-js";
-import { createEffect } from "solid-js";
 import { createWithSignal } from "solid-zustand";
 import { default as wretch } from "wretch";
 
@@ -30,12 +29,19 @@ export interface UserPersonalDetails {
 	nationalityCountryCode: string;
 }
 
+export interface UserSvcProps {
+	queryClient: QueryClient;
+}
+
 export interface UserSvc {
 	isInitialLoading: boolean;
 	profile?: UserProfile | null;
 	syncComplete?: boolean;
 	actions: {
-		init: (token?: string, profile?: KeycloakProfile | null) => void;
+		init: (
+			token?: string,
+			profile?: KeycloakProfile | null,
+		) => Promise<void>;
 		completeSync: (token?: string) => void;
 	};
 }
@@ -51,110 +57,94 @@ const personalDetailsApi = wretch(
 	`${import.meta.env.VITE_API_BASE_URL}/personal-details`,
 );
 
-export const useStore = createWithSignal<UserSvc>((set, get) => {
-	return {
-		isInitialLoading: true,
-		profile: null,
-		actions: {
-			init: once(
-				async (token?: string, profile?: KeycloakProfile | null) => {
-					if (!token || !profile) {
-						set({ isInitialLoading: false });
+export const useStore = (props: UserSvcProps) => {
+	const store = createWithSignal<UserSvc>((set, get) => {
+		return {
+			isInitialLoading: true,
+			profile: null,
+			actions: {
+				init: once(
+					async (
+						token?: string,
+						profile?: KeycloakProfile | null,
+					) => {
+						if (!token || !profile) {
+							set({ isInitialLoading: false });
 
-						return;
-					}
-
-					invariant(profile.email, "No email for keycloak profile");
-
-					const searchParams = new URLSearchParams({
-						email: profile.email,
-					});
-
-					const qUser = useQuery(() => ({
-						queryKey: queryKeys.getUserDetails(token),
-						queryFn: () =>
-							userApi
-								.auth(`Bearer ${token}`)
-								.get(`?${searchParams.toString()}`)
-								.json(normalizeResponse<UserProfile>),
-					}));
-
-					const qPersonalDetails = useQuery(() => ({
-						queryKey: queryKeys.getPersonalDetails(token),
-						queryFn: () =>
-							personalDetailsApi
-								.auth(`Bearer ${token}`)
-								.get(`/user/${qUser.data?.uuid}`)
-								.notFound(() => null)
-								.json(
-									normalizeResponse<UserPersonalDetails | null>,
-								),
-						enabled: Boolean(qUser.data),
-					}));
-
-					const qIm42Config = useQuery(() => ({
-						queryKey: queryKeys.getPersonalDetails(token),
-						queryFn: () =>
-							userApi
-								.auth(`Bearer ${token}`)
-								.get(`/${qUser.data?.uuid}/config/im42`)
-								.json(normalizeResponse<IM42Config>),
-						enabled: Boolean(qUser.data),
-					}));
-
-					createEffect(() => {
-						if (
-							qUser.isLoading ||
-							qPersonalDetails.isLoading ||
-							!qUser.data
-						) {
 							return;
 						}
+
+						invariant(
+							profile.email,
+							"No email for keycloak profile",
+						);
+
+						const searchParams = new URLSearchParams({
+							email: profile.email,
+						});
+
+						const userDetails = await props.queryClient.fetchQuery({
+							queryKey: queryKeys.getUserDetails(token),
+							queryFn: () =>
+								userApi
+									.auth(`Bearer ${token}`)
+									.get(`?${searchParams.toString()}`)
+									.json(normalizeResponse<UserProfile>),
+						});
+
+						const personalDetails =
+							await props.queryClient.fetchQuery({
+								queryKey: queryKeys.getPersonalDetails(token),
+								queryFn: () =>
+									personalDetailsApi
+										.auth(`Bearer ${token}`)
+										.get(`/user/${userDetails.uuid}`)
+										.notFound(() => null)
+										.json(
+											normalizeResponse<UserPersonalDetails | null>,
+										),
+							});
 
 						set({
 							profile: {
-								...qUser.data,
+								...userDetails,
 								phoneNumber:
-									qPersonalDetails.data?.mobileNumber || "",
+									personalDetails?.mobileNumber || "",
 							},
 						});
-					});
 
-					createEffect(() => {
-						if (!qUser.data || !qIm42Config.data) {
-							return;
-						}
+						const im42Config = await props.queryClient.fetchQuery({
+							queryKey: queryKeys.getPersonalDetails(token),
+							queryFn: () =>
+								userApi
+									.auth(`Bearer ${token}`)
+									.get(`/${userDetails.uuid}/config/im42`)
+									.json(normalizeResponse<IM42Config>)
+									.catch(() => Object.create(null)),
+						});
 
 						set({
-							syncComplete: Boolean(qIm42Config.data.syncedAt),
+							syncComplete: Boolean(im42Config.syncedAt),
 						});
-					});
-
-					createEffect(() => {
-						if (
-							qUser.isLoading ||
-							qPersonalDetails.isLoading ||
-							qIm42Config.isLoading
-						) {
-							return;
-						}
 
 						set({ isInitialLoading: false });
-					});
+					},
+				),
+				completeSync: (token?: string) => {
+					const profile = get().profile;
+					if (!token || !profile?.uuid) {
+						return;
+					}
+
+					im42Api
+						.auth(`Bearer ${token}`)
+						.put(`/user/${profile.uuid}/config/synced`);
+
+					set({ syncComplete: true });
 				},
-			),
-			completeSync: (token?: string) => {
-				const profile = get().profile;
-				if (!token || !profile?.uuid) {
-					return;
-				}
-
-				im42Api
-					.auth(`Bearer ${token}`)
-					.put(`/user/${profile.uuid}/config/synced`);
-
-				set({ syncComplete: true });
 			},
-		},
-	};
-});
+		};
+	});
+
+	return store(); // returns an accessor which IS reactive
+};


### PR DESCRIPTION
summary:
- **refactor user context:** avoid using `useQuery` hook within the bear store. `useQuery` is supposed to work within the solid lifecycle, but zustand stores operate outside the solid lifecycle and integrate with it. so mixing the two makes things a little awkward because we kind of have two state management approaches in the same place. however, tanstack query is beneficial because it allows us to invalidate queries from far away when we do mutate the users profile. to get the best of both, the implementation has been refactored so that the api service call is done through `fetchQuery` instead of `useQuery`. passing constructor args to `useStore` is a known pattern: https://zustand.docs.pmnd.rs/guides/initialize-state-with-props

- **handle errors better if store initialisation fails:** if any of the api fetches break unexpectedly (we've not caught and provided a default value) then the entire app breaks with no indication other than a white screen. error boundaries allow us to reset the application login state and refresh the application. to make it work we need to be able to propagate errors inside handlers to the boundary, otherwise the error is thrown and the application breaks but the error boundary will not allow recovery, see:
   - https://github.com/solidjs/solid/discussions/1174
   - https://docs.solidjs.com/reference/components/error-boundary

https://github.com/user-attachments/assets/f2e62626-2cfa-4085-a975-54a43ec4de1b

related:
- #366