### PR TITLE
feat: handle redirects in preview

### DIFF
--- a/api/imigresen-api/src/imigresen_api/app/core.clj
+++ b/api/imigresen-api/src/imigresen_api/app/core.clj
@@ -136,8 +136,8 @@
   (fn [req]
     (let [res (handler req)]
       (if (and (imi-env/preview? (imi-env/current-env))
-               (not (empty? (get-in res [:headers "Location"])))
-               (not (empty? (imi-env/env :buang-deployment-path string? "")))
+               (seq (get-in res [:headers "Location"]))
+               (seq (imi-env/env :buang-deployment-path string? ""))
                (not (str/includes? (get-in res [:headers "Location"]) (imi-env/env :buang-deployment-path string? ""))))
         (assoc-in res [:headers "Location"] (str (imi-env/env :buang-deployment-path string? "") (get-in res [:headers "Location"])))
         res))))

--- a/api/imigresen-api/src/imigresen_api/app/core.clj
+++ b/api/imigresen-api/src/imigresen_api/app/core.clj
@@ -29,7 +29,8 @@
             [ring.logger :as logger]
             [ring.util.response :as ring-res]
             [sentry-clj.core :as sentry]
-            [taoensso.telemere :as tel])
+            [taoensso.telemere :as tel]
+            [clojure.string :as str])
   (:import (java.io Writer)
            (java.util UUID)))
 
@@ -131,6 +132,16 @@
                                                (ring-res/content-type (:plain-text imi-routes/content-types))))
                       :no-doc true}}]])
 
+(defn redirect-preview [handler]
+  (fn [req]
+    (let [res (handler req)]
+      (if (and (imi-env/preview? (imi-env/current-env))
+               (some? (get-in res [:headers "Location"]))
+               (not (empty? (imi-env/env :buang-deployment-path string? "")))
+               (not (str/includes? (get-in res [:headers "Location"]) (imi-env/env :buang-deployment-path string? ""))))
+        (assoc-in res [:headers "Location"] (str (imi-env/env :buang-deployment-path string? "") (get-in res [:headers "Location"])))
+        res))))
+
 (defn create-app [handlers]
   (let [global-middleware [;; CORS
                            imi-cors/cors-middleware
@@ -153,7 +164,9 @@
                            ;; coercing response body (clj -> json, correct types)
                            reitit.ring.coercion/coerce-response-middleware
                            ;; openapi feature
-                           openapi/openapi-feature]
+                           openapi/openapi-feature
+                           ;; handle redirects when deployed as preview
+                           redirect-preview]
         dev-middleware []]
     (reitit-ring/ring-handler
      (reitit-ring/router

--- a/api/imigresen-api/src/imigresen_api/app/core.clj
+++ b/api/imigresen-api/src/imigresen_api/app/core.clj
@@ -136,7 +136,7 @@
   (fn [req]
     (let [res (handler req)]
       (if (and (imi-env/preview? (imi-env/current-env))
-               (some? (get-in res [:headers "Location"]))
+               (not (empty? (get-in res [:headers "Location"])))
                (not (empty? (imi-env/env :buang-deployment-path string? "")))
                (not (str/includes? (get-in res [:headers "Location"]) (imi-env/env :buang-deployment-path string? ""))))
         (assoc-in res [:headers "Location"] (str (imi-env/env :buang-deployment-path string? "") (get-in res [:headers "Location"])))

--- a/api/imigresen-api/src/imigresen_api/app/core.clj
+++ b/api/imigresen-api/src/imigresen_api/app/core.clj
@@ -2,6 +2,7 @@
   (:require [camel-snake-kebab.core :as csk]
             [clj-commons.format.exceptions :as pexceptions]
             [clojure.java.io :as io]
+            [clojure.string :as str]
             [expound.alpha :as expound]
             [imigresen-api.api.core :as imi-core]
             [imigresen-common.app.auth :as imi-auth]
@@ -29,8 +30,7 @@
             [ring.logger :as logger]
             [ring.util.response :as ring-res]
             [sentry-clj.core :as sentry]
-            [taoensso.telemere :as tel]
-            [clojure.string :as str])
+            [taoensso.telemere :as tel])
   (:import (java.io Writer)
            (java.util UUID)))
 


### PR DESCRIPTION
`reitit-ring/redirect-trailing-slash-handler` automatically redirects requests without a trailing slash to the location with a trailing slash. this breaks when we run in preview because traefik strips prefixes before sending the request to the api and so the api does not know that it needs to add the prefix back in when redirecting. so in preview when redirects happen, it goes to the wrong location

https://github.com/metosin/reitit/blob/master/modules/reitit-ring/src/reitit/ring.cljc#L161
<img width="786" height="629" alt="image" src="https://github.com/user-attachments/assets/2e214e85-a9b3-4dee-996d-f5d02a9d98a8" />

for example:
- https://preview.imigresen.skulpture.xyz/deployment/2a6be989e315ad94619b7ba0/docs : wrong location
<img width="924" height="861" alt="image" src="https://github.com/user-attachments/assets/554b6c4d-9b94-44d8-b80c-6bbb9906f259" />

- https://preview.imigresen.skulpture.xyz/deployment/2a6be989e315ad94619b7ba0/docs/ : right location
<img width="924" height="908" alt="image" src="https://github.com/user-attachments/assets/6108a1f5-4dc8-4e8e-bd7b-6178ade4481a" />
