### PR TITLE
chore: bump traefik

### DIFF
--- a/api/imigresen-api/docker-compose.dev.yml
+++ b/api/imigresen-api/docker-compose.dev.yml
@@ -16,7 +16,7 @@ secrets:
 
 services:
     proxy:
-        image: traefik:v3.4
+        image: traefik:v3.6
         ports:
             - target: 443
               published: 443


### PR DESCRIPTION
bump for docker 29

https://gorannikolovski.com/blog/docker-29-and-traefik-compatibility-the-api-version-mismatch